### PR TITLE
Fix: harden FeelIT frontend bootstrap and diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ FeelIT is a modernization of a university-era accessibility project focused on g
 - `/braille-reader`
 - `/haptic-desktop`
 
-The current implementation provides real 3D workspace rendering across all three modes, a stylus-style pointer emulator for no-device execution, scene-native tactile controls in the Braille world, bundled OBJ demo assets, tactile material presets grounded in current desktop-haptics capabilities, and a null-hardware-safe runtime foundation for future physical device integration.
+The current implementation provides real 3D workspace rendering across all three modes, a stylus-style pointer emulator for no-device execution, scene-native tactile controls in the Braille world, visible startup diagnostics for failed workspace boot, bundled OBJ demo assets, tactile material presets grounded in current desktop-haptics capabilities, and a null-hardware-safe runtime foundation for future physical device integration.
 
 ## Current Version
 
-`0.3.0`
+`0.3.1`
 
 ## Public Port
 
@@ -97,6 +97,7 @@ python scripts\browser_scene_smoke.py
 - multi-page frontend shell aligned to the reference workbench style
 - real 3D workspace rendering in all three user modes
 - stylus-style pointer emulation with hover and activation feedback
+- visible startup diagnostics when a workspace fails to initialize
 - bundled OBJ demo assets plus local OBJ upload for staging
 - tactile material catalog exposed at `GET /api/materials`
 - demo model catalog exposed at `GET /api/demo-models`

--- a/app/core/version.py
+++ b/app/core/version.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 APP_NAME = "FeelIT"
-APP_VERSION = "0.3.0"
+APP_VERSION = "0.3.1"
 APP_PUBLISHER = "Felipe Santibanez"
 
 

--- a/app/static/braille_reader.html
+++ b/app/static/braille_reader.html
@@ -183,7 +183,6 @@
     </div>
   </div>
 
-  <script src="/static/js/app.js" defer></script>
   <script type="module" src="/static/js/braille_reader.js"></script>
 </body>
 </html>

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -259,6 +259,12 @@ a {
   background: rgba(194, 151, 255, 0.12);
 }
 
+.status-pill-danger {
+  color: #ff7b72;
+  border-color: rgba(255, 123, 114, 0.38);
+  background: rgba(255, 123, 114, 0.12);
+}
+
 label,
 .panel-text {
   color: var(--text-secondary);
@@ -501,6 +507,38 @@ input[type="range"] {
   background: rgba(13, 17, 23, 0.84);
   color: var(--accent-cyan);
   font-size: 0.78rem;
+}
+
+.stage-error-overlay {
+  position: absolute;
+  inset: 22px;
+  z-index: 4;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 22px;
+  border: 1px solid rgba(255, 123, 114, 0.36);
+  border-radius: 14px;
+  background:
+    linear-gradient(180deg, rgba(13, 17, 23, 0.52), rgba(13, 17, 23, 0.92)),
+    radial-gradient(circle at top left, rgba(255, 123, 114, 0.18), transparent 36%);
+  pointer-events: none;
+}
+
+.stage-error-title {
+  color: #ff7b72;
+  font-size: 0.92rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.stage-error-body {
+  margin: 0;
+  max-width: 560px;
+  color: var(--text-primary);
+  line-height: 1.6;
+  font-size: 0.88rem;
 }
 
 .subsurface-panel {

--- a/app/static/haptic_desktop.html
+++ b/app/static/haptic_desktop.html
@@ -151,7 +151,6 @@
     </div>
   </div>
 
-  <script src="/static/js/app.js" defer></script>
   <script type="module" src="/static/js/haptic_desktop.js"></script>
 </body>
 </html>

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -1,81 +1,208 @@
-(() => {
-  "use strict";
+const healthUrl = "/api/health";
+const metaUrl = "/api/meta";
 
-  const healthUrl = "/api/health";
-  const metaUrl = "/api/meta";
+function byId(id) {
+  return document.getElementById(id);
+}
 
-  function updateRuntimeSlot(name, value) {
-    document.querySelectorAll(`[data-runtime="${name}"]`).forEach((element) => {
-      element.textContent = value;
-    });
+function updateRuntimeSlot(name, value) {
+  document.querySelectorAll(`[data-runtime="${name}"]`).forEach((element) => {
+    element.textContent = value;
+  });
+}
+
+function openModal(modalId) {
+  const modal = byId(modalId);
+  if (modal) {
+    modal.classList.add("modal-visible");
   }
+}
 
-  function openModal(modalId) {
-    const modal = document.getElementById(modalId);
-    if (modal) {
-      modal.classList.add("modal-visible");
-    }
+function closeModal(modalId) {
+  const modal = byId(modalId);
+  if (modal) {
+    modal.classList.remove("modal-visible");
   }
+}
 
-  function closeModal(modalId) {
-    const modal = document.getElementById(modalId);
-    if (modal) {
-      modal.classList.remove("modal-visible");
-    }
+let modalsBound = false;
+
+export function bindModals() {
+  if (modalsBound) {
+    return;
   }
+  modalsBound = true;
 
-  function bindModals() {
-    document.querySelectorAll("[data-open-modal]").forEach((button) => {
-      button.addEventListener("click", () => {
-        openModal(button.getAttribute("data-open-modal"));
-      });
+  document.querySelectorAll("[data-open-modal]").forEach((button) => {
+    button.addEventListener("click", () => {
+      openModal(button.getAttribute("data-open-modal"));
     });
+  });
 
-    document.querySelectorAll("[data-close-modal]").forEach((button) => {
-      button.addEventListener("click", () => {
-        closeModal(button.getAttribute("data-close-modal"));
-      });
+  document.querySelectorAll("[data-close-modal]").forEach((button) => {
+    button.addEventListener("click", () => {
+      closeModal(button.getAttribute("data-close-modal"));
     });
+  });
 
-    document.querySelectorAll(".modal").forEach((modal) => {
-      modal.addEventListener("click", (event) => {
-        if (event.target === modal) {
-          modal.classList.remove("modal-visible");
-        }
-      });
-    });
-
-    document.addEventListener("keydown", (event) => {
-      if (event.key === "Escape") {
-        document.querySelectorAll(".modal.modal-visible").forEach((modal) => {
-          modal.classList.remove("modal-visible");
-        });
+  document.querySelectorAll(".modal").forEach((modal) => {
+    modal.addEventListener("click", (event) => {
+      if (event.target === modal) {
+        modal.classList.remove("modal-visible");
       }
     });
-  }
+  });
 
-  async function fetchJson(url) {
-    const response = await fetch(url);
-    if (!response.ok) {
-      throw new Error(`Request failed: ${url}`);
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") {
+      document.querySelectorAll(".modal.modal-visible").forEach((modal) => {
+        modal.classList.remove("modal-visible");
+      });
     }
-    return response.json();
+  });
+}
+
+async function fetchJson(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Request failed: ${url}`);
+  }
+  return response.json();
+}
+
+function formatErrorMessage(error) {
+  const fallback = "Workspace bootstrap failed.";
+  if (!error) {
+    return fallback;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return fallback;
+}
+
+function resolveStageElement(stageSelector) {
+  if (!stageSelector) {
+    return null;
   }
 
-  async function loadShell() {
-    bindModals();
-    const [health, meta] = await Promise.all([fetchJson(healthUrl), fetchJson(metaUrl)]);
-
-    updateRuntimeSlot("api-status", health.status);
-    updateRuntimeSlot("version", `v${meta.version}`);
-    updateRuntimeSlot("port", String(meta.public_port));
-    updateRuntimeSlot("haptics-mode", health.haptics.mode);
-    updateRuntimeSlot("backend", health.haptics.backend);
-
-    return { health, meta };
+  const target = document.querySelector(stageSelector);
+  if (!target) {
+    return null;
   }
 
-  window.FeelITShell = {
-    loadShell,
-  };
-})();
+  if (target.classList.contains("workspace-stage")) {
+    return target;
+  }
+
+  return target.closest(".workspace-stage");
+}
+
+export function clearStageBootError(stageSelector) {
+  const stage = resolveStageElement(stageSelector);
+  stage?.querySelector(".stage-error-overlay")?.remove();
+}
+
+export function showStageBootError(stageSelector, title, message) {
+  const stage = resolveStageElement(stageSelector);
+  if (!stage) {
+    return;
+  }
+
+  clearStageBootError(stageSelector);
+
+  const overlay = document.createElement("div");
+  overlay.className = "stage-error-overlay";
+
+  const heading = document.createElement("strong");
+  heading.className = "stage-error-title";
+  heading.textContent = title;
+
+  const body = document.createElement("p");
+  body.className = "stage-error-body";
+  body.textContent = message;
+
+  overlay.appendChild(heading);
+  overlay.appendChild(body);
+  stage.appendChild(overlay);
+}
+
+function setElementText(id, text) {
+  const element = byId(id);
+  if (element) {
+    element.textContent = text;
+  }
+}
+
+export async function loadShell() {
+  bindModals();
+  const [health, meta] = await Promise.all([fetchJson(healthUrl), fetchJson(metaUrl)]);
+
+  updateRuntimeSlot("api-status", health.status);
+  updateRuntimeSlot("version", `v${meta.version}`);
+  updateRuntimeSlot("port", String(meta.public_port));
+  updateRuntimeSlot("haptics-mode", health.haptics.mode);
+  updateRuntimeSlot("backend", health.haptics.backend);
+
+  return { health, meta };
+}
+
+export function reportWorkspaceBootError(options, error) {
+  const title = options.title ?? "Workspace startup failed";
+  const message = formatErrorMessage(error);
+  const stageMessage = `Unable to initialize this workspace: ${message}`;
+  const pageStatusText = options.pageStatusText ?? "Boot failed";
+  const pillText = options.runtimePillText ?? "Runtime error";
+
+  console.error(`[${title}] ${message}`, error);
+
+  updateRuntimeSlot("api-status", "error");
+  updateRuntimeSlot("backend", "error");
+  updateRuntimeSlot("haptics-mode", "unavailable");
+  document.querySelectorAll('[data-runtime="version"]').forEach((element) => {
+    if (element.textContent.trim() === "v--" || element.textContent.trim() === "Loading") {
+      element.textContent = "Error";
+    }
+  });
+
+  if (options.runtimePillId) {
+    const pill = byId(options.runtimePillId);
+    if (pill) {
+      pill.textContent = pillText;
+      pill.classList.remove("status-pill-cyan", "status-pill-green", "status-pill-purple");
+      pill.classList.add("status-pill-danger");
+    }
+  }
+
+  if (options.pageStatusId) {
+    setElementText(options.pageStatusId, pageStatusText);
+  }
+  if (options.stageStatusId) {
+    setElementText(options.stageStatusId, stageMessage);
+  }
+  if (options.summaryIds) {
+    options.summaryIds.forEach((id) => setElementText(id, message));
+  }
+
+  showStageBootError(options.stageSelector, title, message);
+}
+
+export async function bootWorkspace(options, callback) {
+  try {
+    const shell = await loadShell();
+    await callback(shell);
+    clearStageBootError(options.stageSelector);
+  } catch (error) {
+    reportWorkspaceBootError(options, error);
+  }
+}
+
+window.FeelITShell = {
+  bindModals,
+  bootWorkspace,
+  loadShell,
+  reportWorkspaceBootError,
+};

--- a/app/static/js/braille_reader.js
+++ b/app/static/js/braille_reader.js
@@ -1,3 +1,4 @@
+import { bootWorkspace } from "./app.js";
 import {
   THREE,
   attachPointerEmulation,
@@ -607,76 +608,94 @@ function moveSelection(sceneApi, deltaRow, deltaColumn) {
   }
 }
 
-document.addEventListener("DOMContentLoaded", async () => {
-  await window.FeelITShell.loadShell();
+document.addEventListener("DOMContentLoaded", () => {
+  bootWorkspace(
+    {
+      title: "Braille Reader startup failed",
+      stageSelector: "#braille-canvas",
+      runtimePillId: "reader-runtime-pill",
+      runtimePillText: "Runtime error",
+      pageStatusId: "reader-page-status",
+      pageStatusText: "Boot failed",
+      stageStatusId: "reader-status-bar",
+      summaryIds: [
+        "selected-source",
+        "selected-normalized",
+        "selected-mask",
+        "selected-position",
+        "summary-unicode",
+      ],
+    },
+    async () => {
+      const sceneApi = createWorkspaceScene(byId("braille-canvas"), {
+        cameraPosition: [2.4, 2.2, 3.2],
+        target: [0, 0.18, 0.08],
+        boundarySize: new THREE.Vector3(3.6, 0.95, 3.2),
+      });
 
-  const sceneApi = createWorkspaceScene(byId("braille-canvas"), {
-    cameraPosition: [2.4, 2.2, 3.2],
-    target: [0, 0.18, 0.08],
-    boundarySize: new THREE.Vector3(3.6, 0.95, 3.2),
-  });
+      state.pointerController = attachPointerEmulation(sceneApi, {
+        initialPosition: new THREE.Vector3(0, 0.22, 0.2),
+        boundsMin: new THREE.Vector3(-1.6, 0.14, -1.2),
+        boundsMax: new THREE.Vector3(1.6, 0.34, 1.4),
+        speed: 1.4,
+        onMove: (position) => updatePointerTarget(sceneApi, position, getPageCells()),
+        onActivate: () => activatePointerTarget(sceneApi, getPageCells()),
+      });
 
-  state.pointerController = attachPointerEmulation(sceneApi, {
-    initialPosition: new THREE.Vector3(0, 0.22, 0.2),
-    boundsMin: new THREE.Vector3(-1.6, 0.14, -1.2),
-    boundsMax: new THREE.Vector3(1.6, 0.34, 1.4),
-    speed: 1.4,
-    onMove: (position) => updatePointerTarget(sceneApi, position, getPageCells()),
-    onActivate: () => activatePointerTarget(sceneApi, getPageCells()),
-  });
+      byId("generate-preview").addEventListener("click", () => {
+        loadPreview(sceneApi).catch((error) => setStatus(error.message, "preview-error"));
+      });
 
-  byId("generate-preview").addEventListener("click", () => {
-    loadPreview(sceneApi).catch((error) => setStatus(error.message, "preview-error"));
-  });
+      byId("load-sample-text").addEventListener("click", () => {
+        byId("preview-text").value =
+          "Braille reading should remain tactile, spatial, and independent from the audio channel when needed.";
+        loadPreview(sceneApi).catch((error) => setStatus(error.message, "sample-error"));
+      });
 
-  byId("load-sample-text").addEventListener("click", () => {
-    byId("preview-text").value =
-      "Braille reading should remain tactile, spatial, and independent from the audio channel when needed.";
-    loadPreview(sceneApi).catch((error) => setStatus(error.message, "sample-error"));
-  });
+      byId("rows-per-page").addEventListener("change", () => {
+        state.rowsPerPage = Number(byId("rows-per-page").value) || 4;
+        state.currentPage = 0;
+        renderCurrentPage(sceneApi);
+      });
 
-  byId("rows-per-page").addEventListener("change", () => {
-    state.rowsPerPage = Number(byId("rows-per-page").value) || 4;
-    state.currentPage = 0;
-    renderCurrentPage(sceneApi);
-  });
+      byId("preview-columns").addEventListener("change", () => {
+        loadPreview(sceneApi).catch((error) => setStatus(error.message, "columns-error"));
+      });
 
-  byId("preview-columns").addEventListener("change", () => {
-    loadPreview(sceneApi).catch((error) => setStatus(error.message, "columns-error"));
-  });
+      byId("cell-scale").addEventListener("change", (event) => {
+        applyScale(event.target.value);
+      });
 
-  byId("cell-scale").addEventListener("change", (event) => {
-    applyScale(event.target.value);
-  });
+      byId("braille-boundary-toggle").addEventListener("change", (event) => {
+        sceneApi.setBoundaryVisible(event.target.checked);
+      });
 
-  byId("braille-boundary-toggle").addEventListener("change", (event) => {
-    sceneApi.setBoundaryVisible(event.target.checked);
-  });
+      byId("prev-page").addEventListener("click", () => {
+        state.currentPage = Math.max(0, state.currentPage - 1);
+        state.selectedCellId = null;
+        renderCurrentPage(sceneApi);
+        setStatus("Moved to previous page with fallback web control.", "fallback-prev");
+      });
 
-  byId("prev-page").addEventListener("click", () => {
-    state.currentPage = Math.max(0, state.currentPage - 1);
-    state.selectedCellId = null;
-    renderCurrentPage(sceneApi);
-    setStatus("Moved to previous page with fallback web control.", "fallback-prev");
-  });
+      byId("next-page").addEventListener("click", () => {
+        state.currentPage = Math.min(getPageCount() - 1, state.currentPage + 1);
+        state.selectedCellId = null;
+        renderCurrentPage(sceneApi);
+        setStatus("Moved to next page with fallback web control.", "fallback-next");
+      });
 
-  byId("next-page").addEventListener("click", () => {
-    state.currentPage = Math.min(getPageCount() - 1, state.currentPage + 1);
-    state.selectedCellId = null;
-    renderCurrentPage(sceneApi);
-    setStatus("Moved to next page with fallback web control.", "fallback-next");
-  });
+      document.addEventListener("keydown", (event) => {
+        if (event.target.tagName === "TEXTAREA" || event.target.tagName === "INPUT") {
+          return;
+        }
+        if (event.key === "ArrowLeft") moveSelection(sceneApi, 0, -1);
+        if (event.key === "ArrowRight") moveSelection(sceneApi, 0, 1);
+        if (event.key === "ArrowUp") moveSelection(sceneApi, -1, 0);
+        if (event.key === "ArrowDown") moveSelection(sceneApi, 1, 0);
+      });
 
-  document.addEventListener("keydown", (event) => {
-    if (event.target.tagName === "TEXTAREA" || event.target.tagName === "INPUT") {
-      return;
-    }
-    if (event.key === "ArrowLeft") moveSelection(sceneApi, 0, -1);
-    if (event.key === "ArrowRight") moveSelection(sceneApi, 0, 1);
-    if (event.key === "ArrowUp") moveSelection(sceneApi, -1, 0);
-    if (event.key === "ArrowDown") moveSelection(sceneApi, 1, 0);
-  });
-
-  applyScale("standard");
-  await loadPreview(sceneApi);
+      applyScale("standard");
+      await loadPreview(sceneApi);
+    },
+  );
 });

--- a/app/static/js/haptic_desktop.js
+++ b/app/static/js/haptic_desktop.js
@@ -1,3 +1,4 @@
+import { bootWorkspace } from "./app.js";
 import {
   THREE,
   attachPointerEmulation,
@@ -496,54 +497,66 @@ function activatePointerTarget(sceneApi) {
   activateFocusedItem(sceneApi, "pointer");
 }
 
-document.addEventListener("DOMContentLoaded", async () => {
-  await window.FeelITShell.loadShell();
+document.addEventListener("DOMContentLoaded", () => {
+  bootWorkspace(
+    {
+      title: "Haptic Desktop startup failed",
+      stageSelector: "#desktop-canvas",
+      runtimePillId: "desktop-runtime-pill",
+      runtimePillText: "Runtime error",
+      pageStatusId: "desktop-page-status",
+      pageStatusText: "Boot failed",
+      stageStatusId: "desktop-status-bar",
+      summaryIds: ["desktop-focus-label", "desktop-focus-type", "desktop-focus-action", "desktop-announcement"],
+    },
+    async () => {
+      const sceneApi = createWorkspaceScene(byId("desktop-canvas"), {
+        cameraPosition: [4.2, 3.0, 4.2],
+        target: [0, 0.38, 0],
+        boundarySize: new THREE.Vector3(5.0, 1.4, 3.8),
+      });
 
-  const sceneApi = createWorkspaceScene(byId("desktop-canvas"), {
-    cameraPosition: [4.2, 3.0, 4.2],
-    target: [0, 0.38, 0],
-    boundarySize: new THREE.Vector3(5.0, 1.4, 3.8),
-  });
+      state.pointerController = attachPointerEmulation(sceneApi, {
+        initialPosition: new THREE.Vector3(-1.1, 0.72, -0.2),
+        boundsMin: new THREE.Vector3(-2.1, 0.18, -1.55),
+        boundsMax: new THREE.Vector3(2.1, 0.95, 1.55),
+        speed: 1.7,
+        onMove: (position) => updatePointerFocus(sceneApi, position),
+        onActivate: () => activatePointerTarget(sceneApi),
+      });
 
-  state.pointerController = attachPointerEmulation(sceneApi, {
-    initialPosition: new THREE.Vector3(-1.1, 0.72, -0.2),
-    boundsMin: new THREE.Vector3(-2.1, 0.18, -1.55),
-    boundsMax: new THREE.Vector3(2.1, 0.95, 1.55),
-    speed: 1.7,
-    onMove: (position) => updatePointerFocus(sceneApi, position),
-    onActivate: () => activatePointerTarget(sceneApi),
-  });
+      renderLayout(sceneApi);
 
-  renderLayout(sceneApi);
+      byId("focus-prev").addEventListener("click", () => moveFocus(sceneApi, -1));
+      byId("focus-next").addEventListener("click", () => moveFocus(sceneApi, 1));
+      byId("focus-activate").addEventListener("click", () => activateFocusedItem(sceneApi, "fallback"));
 
-  byId("focus-prev").addEventListener("click", () => moveFocus(sceneApi, -1));
-  byId("focus-next").addEventListener("click", () => moveFocus(sceneApi, 1));
-  byId("focus-activate").addEventListener("click", () => activateFocusedItem(sceneApi, "fallback"));
+      byId("layout-preset").addEventListener("change", (event) => {
+        state.layout = event.target.value;
+        renderLayout(sceneApi);
+        announce(`Layout preset changed to ${event.target.value}.`);
+      });
 
-  byId("layout-preset").addEventListener("change", (event) => {
-    state.layout = event.target.value;
-    renderLayout(sceneApi);
-    announce(`Layout preset changed to ${event.target.value}.`);
-  });
+      byId("audio-cues-toggle").addEventListener("change", (event) => {
+        byId("desktop-audio-state").textContent = event.target.checked ? "On" : "Off";
+        announce(event.target.checked ? "Audio cue labels enabled." : "Audio cue labels disabled.");
+      });
 
-  byId("audio-cues-toggle").addEventListener("change", (event) => {
-    byId("desktop-audio-state").textContent = event.target.checked ? "On" : "Off";
-    announce(event.target.checked ? "Audio cue labels enabled." : "Audio cue labels disabled.");
-  });
+      byId("pointer-toggle").addEventListener("change", (event) => {
+        sceneApi.setPointerVisible(event.target.checked);
+      });
 
-  byId("pointer-toggle").addEventListener("change", (event) => {
-    sceneApi.setPointerVisible(event.target.checked);
-  });
-
-  document.addEventListener("keydown", (event) => {
-    if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
-      moveFocus(sceneApi, -1);
-    }
-    if (event.key === "ArrowRight" || event.key === "ArrowDown") {
-      moveFocus(sceneApi, 1);
-    }
-    if (event.key === "Enter") {
-      activateFocusedItem(sceneApi, "fallback");
-    }
-  });
+      document.addEventListener("keydown", (event) => {
+        if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+          moveFocus(sceneApi, -1);
+        }
+        if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+          moveFocus(sceneApi, 1);
+        }
+        if (event.key === "Enter") {
+          activateFocusedItem(sceneApi, "fallback");
+        }
+      });
+    },
+  );
 });

--- a/app/static/js/object_explorer.js
+++ b/app/static/js/object_explorer.js
@@ -1,3 +1,4 @@
+import { bootWorkspace } from "./app.js";
 import { OBJLoader } from "../vendor/three/OBJLoader.js";
 import { THREE, attachPointerEmulation, createWorkspaceScene } from "./three_scene_common.js";
 
@@ -241,89 +242,102 @@ async function loadSelectedModel(sceneApi) {
   });
 }
 
-document.addEventListener("DOMContentLoaded", async () => {
-  const shell = await window.FeelITShell.loadShell();
-  const sceneApi = createWorkspaceScene(byId("object-canvas"), {
-    cameraPosition: [3.8, 2.9, 4.8],
-    target: [0, 0.8, 0],
-  });
+document.addEventListener("DOMContentLoaded", () => {
+  bootWorkspace(
+    {
+      title: "3D Object Explorer startup failed",
+      stageSelector: "#object-canvas",
+      runtimePillId: "explorer-stage-pill",
+      runtimePillText: "Runtime error",
+      pageStatusId: "explorer-page-status",
+      pageStatusText: "Boot failed",
+      stageStatusId: "object-stage-status",
+      summaryIds: ["material-summary", "stage-model-description"],
+    },
+    async (shell) => {
+      const sceneApi = createWorkspaceScene(byId("object-canvas"), {
+        cameraPosition: [3.8, 2.9, 4.8],
+        target: [0, 0.8, 0],
+      });
 
-  state.pointerController = attachPointerEmulation(sceneApi, {
-    initialPosition: new THREE.Vector3(0, 0.45, 0),
-    boundsMin: new THREE.Vector3(-1.9, 0.12, -1.9),
-    boundsMax: new THREE.Vector3(1.9, 2.3, 1.9),
-    speed: 1.65,
-    onMove: (position) => updatePointerFeedback(sceneApi, position),
-    onActivate: () => activatePointer(sceneApi),
-  });
+      state.pointerController = attachPointerEmulation(sceneApi, {
+        initialPosition: new THREE.Vector3(0, 0.45, 0),
+        boundsMin: new THREE.Vector3(-1.9, 0.12, -1.9),
+        boundsMax: new THREE.Vector3(1.9, 2.3, 1.9),
+        speed: 1.65,
+        onMove: (position) => updatePointerFeedback(sceneApi, position),
+        onActivate: () => activatePointer(sceneApi),
+      });
 
-  const [materialPayload, modelPayload] = await Promise.all([
-    fetchJson(materialsUrl),
-    fetchJson(demoModelsUrl),
-  ]);
+      const [materialPayload, modelPayload] = await Promise.all([
+        fetchJson(materialsUrl),
+        fetchJson(demoModelsUrl),
+      ]);
 
-  state.materials = materialPayload.materials;
-  state.models = modelPayload.models;
+      state.materials = materialPayload.materials;
+      state.models = modelPayload.models;
 
-  populateSelect(byId("material-select"), state.materials, "slug", "title");
-  populateSelect(byId("sample-model"), state.models, "slug", "title");
+      populateSelect(byId("material-select"), state.materials, "slug", "title");
+      populateSelect(byId("sample-model"), state.models, "slug", "title");
 
-  const initialModel = state.models[0];
-  byId("sample-model").value = initialModel.slug;
-  byId("material-select").value = initialModel.default_material;
-  state.currentMaterial = materialBySlug(initialModel.default_material);
-  updateMaterialPanel(state.currentMaterial);
+      const initialModel = state.models[0];
+      byId("sample-model").value = initialModel.slug;
+      byId("material-select").value = initialModel.default_material;
+      state.currentMaterial = materialBySlug(initialModel.default_material);
+      updateMaterialPanel(state.currentMaterial);
 
-  byId("explorer-stage-pill").textContent =
-    shell.health.haptics.mode === "available" ? "Haptic ready" : "Pointer emulator";
+      byId("explorer-stage-pill").textContent =
+        shell.health.haptics.mode === "available" ? "Haptic ready" : "Pointer emulator";
 
-  byId("load-selection").addEventListener("click", () => {
-    loadSelectedModel(sceneApi).catch(() => {
-      setStatus("Model loading failed.");
-    });
-  });
+      byId("load-selection").addEventListener("click", () => {
+        loadSelectedModel(sceneApi).catch(() => {
+          setStatus("Model loading failed.");
+        });
+      });
 
-  byId("reset-camera").addEventListener("click", () => {
-    sceneApi.resetCamera();
-    setStatus("Camera reset to default framing.");
-  });
+      byId("reset-camera").addEventListener("click", () => {
+        sceneApi.resetCamera();
+        setStatus("Camera reset to default framing.");
+      });
 
-  byId("sample-model").addEventListener("change", () => {
-    const model = modelBySlug(byId("sample-model").value);
-    byId("material-select").value = model.default_material;
-    state.currentMaterial = materialBySlug(model.default_material);
-    updateMaterialPanel(state.currentMaterial);
-    updateModelInspector(model);
-    setStatus(`Selected ${model.title}.`);
-  });
+      byId("sample-model").addEventListener("change", () => {
+        const model = modelBySlug(byId("sample-model").value);
+        byId("material-select").value = model.default_material;
+        state.currentMaterial = materialBySlug(model.default_material);
+        updateMaterialPanel(state.currentMaterial);
+        updateModelInspector(model);
+        setStatus(`Selected ${model.title}.`);
+      });
 
-  byId("material-select").addEventListener("change", () => {
-    state.currentMaterial = materialBySlug(byId("material-select").value);
-    updateMaterialPanel(state.currentMaterial);
-    if (state.currentObject) {
-      applyMaterialToObject(state.currentObject, state.currentMaterial);
-    }
-    setStatus(`Applied ${state.currentMaterial.title}.`);
-  });
+      byId("material-select").addEventListener("change", () => {
+        state.currentMaterial = materialBySlug(byId("material-select").value);
+        updateMaterialPanel(state.currentMaterial);
+        if (state.currentObject) {
+          applyMaterialToObject(state.currentObject, state.currentMaterial);
+        }
+        setStatus(`Applied ${state.currentMaterial.title}.`);
+      });
 
-  byId("workspace-scale").addEventListener("input", () => {
-    const value = Number(byId("workspace-scale").value);
-    byId("workspace-scale-value").textContent = `${value}%`;
-  });
+      byId("workspace-scale").addEventListener("input", () => {
+        const value = Number(byId("workspace-scale").value);
+        byId("workspace-scale-value").textContent = `${value}%`;
+      });
 
-  byId("guidance-grid-toggle").addEventListener("change", (event) => {
-    sceneApi.setGridVisible(event.target.checked);
-  });
+      byId("guidance-grid-toggle").addEventListener("change", (event) => {
+        sceneApi.setGridVisible(event.target.checked);
+      });
 
-  byId("boundary-toggle").addEventListener("change", (event) => {
-    sceneApi.setBoundaryVisible(event.target.checked);
-  });
+      byId("boundary-toggle").addEventListener("change", (event) => {
+        sceneApi.setBoundaryVisible(event.target.checked);
+      });
 
-  byId("pointer-toggle").addEventListener("change", (event) => {
-    sceneApi.setPointerVisible(event.target.checked);
-  });
+      byId("pointer-toggle").addEventListener("change", (event) => {
+        sceneApi.setPointerVisible(event.target.checked);
+      });
 
-  updateModelInspector(initialModel);
-  await loadSelectedModel(sceneApi);
-  updatePointerFeedback(sceneApi, state.pointerController.position);
+      updateModelInspector(initialModel);
+      await loadSelectedModel(sceneApi);
+      updatePointerFeedback(sceneApi, state.pointerController.position);
+    },
+  );
 });

--- a/app/static/object_explorer.html
+++ b/app/static/object_explorer.html
@@ -174,7 +174,6 @@
     </div>
   </div>
 
-  <script src="/static/js/app.js" defer></script>
   <script type="module" src="/static/js/object_explorer.js"></script>
 </body>
 </html>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,6 +30,8 @@ All user workspaces share:
 - help modal pattern
 - dark technical visual language
 - a real 3D scene as the primary workspace for spatial modes
+- module-based frontend bootstrap through the shared shell helper
+- visible boot diagnostics when runtime initialization fails
 
 Current shared files:
 

--- a/docs/development_history.md
+++ b/docs/development_history.md
@@ -15,6 +15,21 @@ The archived user manual describes the software as a digital-to-relief presentat
 
 ## Modern Rebuild Timeline
 
+### v0.3.1 (2026-03-29)
+
+Release focused on reliable frontend bootstrap, visible startup diagnostics, and regression coverage for runtime placeholders.
+
+Delivered:
+
+- Replaced the fragile global shell bootstrap with module-based imports shared by the three workspace entrypoints.
+- Added visible workspace boot diagnostics so stale placeholders such as v--, Loading, or Waiting are no longer silent failure states.
+- Hardened the browser smoke validator to fail when runtime metadata placeholders do not initialize.
+
+Rationale:
+
+- Eliminate bootstrap races that can leave the frontend shell and 3D scenes uninitialized in some real browser runs.
+- Turn user-visible startup ambiguity into explicit diagnostics and automated regression coverage.
+
 ### v0.3.0 (2026-03-29)
 
 Release focused on trustworthy 3D interaction worlds, stylus-style pointer emulation, and scene-native tactile controls.

--- a/docs/implementation_gap_audit.md
+++ b/docs/implementation_gap_audit.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document separates what FeelIT `0.3.0` demonstrably implements today from what remains partial, planned, or hardware-dependent.
+This document separates what FeelIT `0.3.1` demonstrably implements today from what remains partial, planned, or hardware-dependent.
 
 It is intentionally conservative. If a behavior is not visible in the runtime, testable through the current repo, or clearly encoded in the shipped code path, it is not treated here as delivered.
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -106,6 +106,8 @@ All pages expose:
 
 If no physical haptic device is configured, the application remains usable in visual fallback mode.
 
+If a workspace cannot initialize correctly, the stage should now expose a visible startup error instead of remaining silently stuck in placeholder states such as `v--`, `Loading`, or `Waiting`.
+
 ## Browser Smoke Validation
 
 For scene-regression checks beyond API tests:

--- a/installer/pyinstaller_version_info.txt
+++ b/installer/pyinstaller_version_info.txt
@@ -1,7 +1,7 @@
 VSVersionInfo(
   ffi=FixedFileInfo(
-    filevers=(0, 3, 0, 0),
-    prodvers=(0, 3, 0, 0),
+    filevers=(0, 3, 1, 0),
+    prodvers=(0, 3, 1, 0),
     mask=0x3F,
     flags=0x0,
     OS=0x40004,
@@ -16,11 +16,11 @@ VSVersionInfo(
         [
           StringStruct('CompanyName', 'Felipe Santibanez'),
           StringStruct('FileDescription', 'FeelIT'),
-          StringStruct('FileVersion', '0.3.0.0'),
+          StringStruct('FileVersion', '0.3.1.0'),
           StringStruct('InternalName', 'FeelIT'),
           StringStruct('OriginalFilename', 'FeelIT.exe'),
           StringStruct('ProductName', 'FeelIT'),
-          StringStruct('ProductVersion', '0.3.0')
+          StringStruct('ProductVersion', '0.3.1')
         ]
       )
     ]),

--- a/installer/version.iss
+++ b/installer/version.iss
@@ -1,4 +1,4 @@
 #define AppName "FeelIT"
-#define AppVersion "0.3.0"
+#define AppVersion "0.3.1"
 #define AppPublisher "Felipe Santibanez"
 #define AppExeName "FeelIT.exe"

--- a/scripts/browser_scene_smoke.py
+++ b/scripts/browser_scene_smoke.py
@@ -86,6 +86,9 @@ def run_browser_smoke(base_url: str, screenshot_dir: Path) -> None:
             screenshot_path = screenshot_dir / f"{scene.route.strip('/').replace('-', '_')}.png"
             page.locator(scene.canvas_selector).screenshot(path=str(screenshot_path))
             unique_colors = measure_canvas_colors(screenshot_path)
+            version_text = (page.locator('[data-runtime="version"]').first.text_content() or "").strip()
+            api_status_text = (page.locator('[data-runtime="api-status"]').first.text_content() or "").strip()
+            error_overlay_count = page.locator(".stage-error-overlay").count()
 
             error_logs = [
                 line for line in console_messages
@@ -100,8 +103,18 @@ def run_browser_smoke(base_url: str, screenshot_dir: Path) -> None:
                     f"{scene.route} canvas looks under-rendered: "
                     f"{unique_colors} unique colors < {scene.min_unique_colors}",
                 )
+            if version_text in {"", "v--", "Loading", "Error"}:
+                failures.append(f"{scene.route} runtime version slot did not initialize: {version_text!r}")
+            if api_status_text in {"", "Loading", "error"}:
+                failures.append(f"{scene.route} API status slot did not initialize: {api_status_text!r}")
+            if error_overlay_count:
+                failures.append(f"{scene.route} rendered a visible stage boot error overlay")
 
-            print(f"{scene.route}: unique_colors={unique_colors} screenshot={screenshot_path}")
+            print(
+                f"{scene.route}: unique_colors={unique_colors} "
+                f"version={version_text} api_status={api_status_text} "
+                f"screenshot={screenshot_path}",
+            )
             page.close()
 
         browser.close()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -52,14 +52,20 @@ def test_frontend_mode_routes_are_served() -> None:
     assert object_response.status_code == 200
     assert "3D Object Explorer" in object_response.text
     assert "Space activate" in object_response.text
+    assert 'type="module" src="/static/js/object_explorer.js"' in object_response.text
+    assert '/static/js/app.js" defer' not in object_response.text
     assert braille_response.status_code == 200
     assert "Braille Reader" in braille_response.text
     assert "Previous Page (Fallback)" in braille_response.text
     assert "WASD/QE pointer" in braille_response.text
+    assert 'type="module" src="/static/js/braille_reader.js"' in braille_response.text
+    assert '/static/js/app.js" defer' not in braille_response.text
     assert desktop_response.status_code == 200
     assert "Haptic Desktop" in desktop_response.text
     assert "Activate (Fallback)" in desktop_response.text
     assert "Space activate" in desktop_response.text
+    assert 'type="module" src="/static/js/haptic_desktop.js"' in desktop_response.text
+    assert '/static/js/app.js" defer' not in desktop_response.text
 
 
 def test_three_vendor_runtime_assets_are_served() -> None:


### PR DESCRIPTION
## Summary
- replace the fragile global shell bootstrap path with module-based shared-shell imports across the three workspace entrypoints
- add visible stage boot diagnostics so stale placeholders such as `v--`, `Loading`, or `Waiting` are no longer silent failure states
- strengthen the browser smoke validator so it fails when runtime metadata placeholders do not initialize
- release the fix as FeelIT `0.3.1`

## Verification
- `python -m pytest tests -v`
- `python -m compileall app tests run_app.py scripts`
- `python scripts/browser_scene_smoke.py`

Closes #12