### PR TITLE
Feat: deliver workspace-driven haptic desktop baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,18 @@ Modern accessibility-centered haptic application for tactile 3D object explorati
 
 ## Overview
 
-FeelIT is a modernization of a university-era accessibility project focused on giving people with visual impairment a richer way to access shape, texture, and text through bounded haptic interaction. The modern repository is organized as a multi-workspace application with three dedicated routes rather than a single scrolling page:
+FeelIT is a modernization of a university-era accessibility project focused on giving people with visual impairment a richer way to access shape, texture, and text through bounded haptic interaction. The modern repository is organized as a multi-workspace application with four dedicated routes rather than a single scrolling page:
 
 - `/object-explorer`
 - `/braille-reader`
 - `/haptic-desktop`
+- `/haptic-workspace-manager`
 
-The current implementation provides real 3D workspace rendering across all three modes, a stylus-style pointer emulator for no-device execution, scene-native tactile controls in the Braille world, visible startup diagnostics for failed workspace boot, bundled OBJ demo assets, a bundled public-domain reading and audio library, tactile material presets grounded in current desktop-haptics capabilities, and a null-hardware-safe runtime foundation for future physical device integration.
+The current implementation provides real 3D workspace rendering across the spatial modes, a stylus-style pointer emulator for no-device execution, scene-native tactile controls in the Braille world, visible startup diagnostics for failed workspace boot, bundled OBJ demo assets, a bundled public-domain reading and audio library, a structured `haptic_workspace` format with a Workspace Manager route, and a null-hardware-safe runtime foundation for future physical device integration.
 
 ## Current Version
 
-`0.4.0`
+`0.5.0`
 
 ## Public Port
 
@@ -41,7 +42,11 @@ Operational workspace that translates text into Braille cells, lays them out on 
 
 ### Haptic Desktop
 
-Prototype workspace for shape-coded action objects that stand in for folders, media, settings, and other desktop interactions inside a bounded 3D desktop scene.
+Workspace-driven tactile desktop that now transitions through a launcher, curated galleries, a file browser, item detail plaques, and opened scenes for models, text, and audio.
+
+### Haptic Workspace Manager
+
+Dedicated management route for creating and registering structured `haptic_workspace` descriptors rooted in external folders on the user's machine.
 
 ## Bundled Demo Assets
 
@@ -77,6 +82,22 @@ These are exposed through:
 
 See [Library Catalog](docs/library_catalog.md) and [Asset Sources](docs/asset_sources.md).
 
+## Haptic Workspace System
+
+FeelIT now includes a structured workspace layer for Haptic Desktop:
+
+- bundled demo workspace file: `app/static/assets/workspaces/feelit_demo.haptic_workspace.json`
+- API catalog and management endpoints:
+  - `GET /api/haptic-workspaces`
+  - `GET /api/haptic-workspaces/{slug}`
+  - `GET /api/haptic-workspaces/{slug}/browse`
+  - `GET /api/haptic-workspaces/{slug}/text-file`
+  - `GET /api/haptic-workspaces/{slug}/raw-file`
+  - `POST /api/haptic-workspaces/create`
+  - `POST /api/haptic-workspaces/register`
+
+The demo desktop workspace uses curated galleries plus a file-browser root. User-created workspaces keep their heavy assets outside the repository and only register descriptor files locally.
+
 ## Quick Start
 
 ### 1. Create the environment
@@ -98,6 +119,7 @@ Open one of the mode routes:
 - `http://127.0.0.1:8101/object-explorer`
 - `http://127.0.0.1:8101/braille-reader`
 - `http://127.0.0.1:8101/haptic-desktop`
+- `http://127.0.0.1:8101/haptic-workspace-manager`
 
 ### 3. Run tests
 
@@ -116,7 +138,7 @@ python scripts\browser_scene_smoke.py
 ## Runtime Capabilities
 
 - FastAPI backend on port `8101`
-- multi-page frontend shell aligned to the reference workbench style
+- four-page frontend shell aligned to the reference workbench style
 - real 3D workspace rendering in all three user modes
 - stylus-style pointer emulation with hover and activation feedback
 - visible startup diagnostics when a workspace fails to initialize
@@ -127,9 +149,10 @@ python scripts\browser_scene_smoke.py
 - document library catalog exposed at `GET /api/library/documents`
 - document segment loading exposed at `GET /api/library/documents/{slug}`
 - audio catalog exposed at `GET /api/library/audio`
+- structured haptic workspace catalog and management endpoints
 - Braille preview API at `POST /api/braille/preview`
 - bounded 3D Braille world with scene-native page controls plus auxiliary inspection board
-- prototype 3D desktop scene with distinct tactile object families
+- workspace-driven 3D desktop launcher, galleries, file browser, detail scenes, and opened content scenes
 - null haptic backend abstraction for no-device execution
 - shared runtime metadata for version, port, and device state
 

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -3,12 +3,23 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
 from app.core.braille import layout_braille_cells, translate_text_to_cells
 from app.core.config import APP_NAME, APP_PORT, APP_VERSION
 from app.core.demo_assets import build_demo_model_catalog
 from app.core.haptic_materials import build_material_catalog
+from app.core.haptic_workspace import (
+    build_haptic_workspace_catalog,
+    build_haptic_workspace_payload,
+    build_workspace_browser_payload,
+    build_workspace_manager_payload,
+    build_workspace_text_payload,
+    create_workspace_file,
+    raw_workspace_file_path,
+    register_workspace_file,
+)
 from app.core.library_assets import (
     build_audio_catalog,
     build_document_catalog,
@@ -24,6 +35,22 @@ class BraillePreviewRequest(BaseModel):
 
     text: str = Field(..., min_length=1, max_length=4000)
     columns: int = Field(default=12, ge=1, le=40)
+
+
+class RegisterHapticWorkspaceRequest(BaseModel):
+    """Payload for registering an existing workspace descriptor file."""
+
+    workspace_file_path: str = Field(..., min_length=1, max_length=2048)
+
+
+class CreateHapticWorkspaceRequest(BaseModel):
+    """Payload for creating a new workspace descriptor file."""
+
+    title: str = Field(..., min_length=1, max_length=120)
+    slug: str | None = Field(default=None, max_length=120)
+    description: str = Field(default="", max_length=500)
+    root_path: str = Field(..., min_length=1, max_length=2048)
+    auto_populate: bool = True
 
 
 @router.get("/health")
@@ -94,6 +121,108 @@ async def library_document(
 async def library_audio() -> dict:
     """Return the bundled audio library catalog."""
     return {"audio": build_audio_catalog()}
+
+
+@router.get("/haptic-workspaces")
+async def haptic_workspaces() -> dict:
+    """Return the catalog of known Haptic Desktop workspaces."""
+    return build_workspace_manager_payload()
+
+
+@router.get("/haptic-workspaces/{slug}")
+async def haptic_workspace_detail(slug: str) -> dict:
+    """Return a resolved Haptic Desktop workspace payload."""
+    try:
+        return build_haptic_workspace_payload(slug)
+    except KeyError as error:
+        raise HTTPException(status_code=404, detail=f"Unknown workspace slug: {slug}") from error
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+
+
+@router.get("/haptic-workspaces/{slug}/browse")
+async def haptic_workspace_browse(
+    slug: str,
+    path: str = Query(default="", max_length=2048),
+) -> dict:
+    """Browse the configured file-browser root for one workspace."""
+    try:
+        return build_workspace_browser_payload(slug, path)
+    except KeyError as error:
+        raise HTTPException(status_code=404, detail=f"Unknown workspace slug: {slug}") from error
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+
+
+@router.get("/haptic-workspaces/{slug}/text-file")
+async def haptic_workspace_text_file(
+    slug: str,
+    path: str = Query(..., min_length=1, max_length=2048),
+    offset: int = Query(default=0, ge=0),
+    max_chars: int = Query(default=1200, ge=250, le=4000),
+) -> dict:
+    """Return a segmented text payload for one raw workspace file."""
+    try:
+        return build_workspace_text_payload(slug, path, offset=offset, max_chars=max_chars)
+    except KeyError as error:
+        raise HTTPException(status_code=404, detail=f"Unknown workspace slug: {slug}") from error
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+
+
+@router.get("/haptic-workspaces/{slug}/raw-file")
+async def haptic_workspace_raw_file(
+    slug: str,
+    path: str = Query(..., min_length=1, max_length=2048),
+) -> FileResponse:
+    """Stream a raw workspace file under the safe configured root."""
+    try:
+        file_path = raw_workspace_file_path(slug, path)
+        return FileResponse(file_path)
+    except KeyError as error:
+        raise HTTPException(status_code=404, detail=f"Unknown workspace slug: {slug}") from error
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+
+
+@router.post("/haptic-workspaces/register")
+async def haptic_workspace_register(payload: RegisterHapticWorkspaceRequest) -> dict:
+    """Register an existing user workspace descriptor."""
+    try:
+        record = register_workspace_file(payload.workspace_file_path)
+        return {
+            "registered": True,
+            "workspace": {
+                "slug": record["slug"],
+                "title": record["title"],
+                "workspace_file_path": record["workspace_file_path"],
+            },
+        }
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+
+
+@router.post("/haptic-workspaces/create")
+async def haptic_workspace_create(payload: CreateHapticWorkspaceRequest) -> dict:
+    """Create and register a new user workspace descriptor."""
+    try:
+        record = create_workspace_file(
+            title=payload.title,
+            slug=payload.slug,
+            description=payload.description,
+            root_path=payload.root_path,
+            auto_populate=payload.auto_populate,
+        )
+        return {
+            "created": True,
+            "workspace": {
+                "slug": record["slug"],
+                "title": record["title"],
+                "workspace_file_path": record["workspace_file_path"],
+            },
+        }
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
 
 
 @router.get("/device/status")

--- a/app/core/haptic_workspace.py
+++ b/app/core/haptic_workspace.py
@@ -1,0 +1,480 @@
+"""Workspace descriptors and filesystem services for the Haptic Desktop."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from app.core.demo_assets import build_demo_model_catalog
+from app.core.library_assets import (
+    build_audio_catalog,
+    build_document_catalog,
+    build_document_payload,
+    build_text_payload_from_path,
+)
+
+APP_DIR = Path(__file__).resolve().parents[1]
+STATIC_DIR = APP_DIR / "static"
+WORKSPACES_DIR = STATIC_DIR / "assets" / "workspaces"
+DEMO_WORKSPACE_FILE = WORKSPACES_DIR / "feelit_demo.haptic_workspace.json"
+WORKSPACE_FORMAT = "feelit_haptic_workspace"
+WORKSPACE_SUFFIX = ".haptic_workspace.json"
+SUPPORTED_MODEL_SUFFIXES = {".obj"}
+SUPPORTED_TEXT_SUFFIXES = {".txt", ".html", ".htm", ".epub", ".md"}
+SUPPORTED_AUDIO_SUFFIXES = {".mp3", ".wav", ".ogg", ".m4a"}
+DEFAULT_SEGMENT_CHARS = 1200
+
+
+def local_app_state_dir() -> Path:
+    """Return the local writable directory used for user-scoped FeelIT state."""
+    if os.name == "nt":
+        root = Path(os.getenv("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
+        return root / "FeelIT"
+    return Path.home() / ".feelit"
+
+
+REGISTRY_FILE = local_app_state_dir() / "haptic_workspace_registry.json"
+
+
+def _slugify(value: str) -> str:
+    """Normalize a user-facing name into a filesystem-safe slug."""
+    slug = re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_")
+    return slug or "workspace"
+
+
+def _ensure_registry_file() -> None:
+    """Create the local workspace registry file when it does not exist yet."""
+    REGISTRY_FILE.parent.mkdir(parents=True, exist_ok=True)
+    if not REGISTRY_FILE.exists():
+        REGISTRY_FILE.write_text(json.dumps({"workspace_files": []}, indent=2), encoding="utf-8")
+
+
+def _load_registry_payload() -> dict[str, Any]:
+    """Return the current local registry payload."""
+    _ensure_registry_file()
+    payload = json.loads(REGISTRY_FILE.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or "workspace_files" not in payload:
+        payload = {"workspace_files": []}
+    return payload
+
+
+def _save_registry_payload(payload: dict[str, Any]) -> None:
+    """Persist the local registry payload."""
+    _ensure_registry_file()
+    REGISTRY_FILE.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _resolve_location(descriptor_path: Path, location: dict[str, Any]) -> Path:
+    """Resolve a descriptor location object into an absolute filesystem path."""
+    mode = location.get("mode")
+    raw_path = location.get("path", "")
+    if not raw_path:
+        raise ValueError("Workspace location path is required.")
+
+    if mode == "absolute":
+        return Path(raw_path).expanduser().resolve()
+    if mode == "workspace_relative":
+        return (descriptor_path.parent / raw_path).resolve()
+    if mode == "app_static_relative":
+        return (STATIC_DIR / raw_path).resolve()
+    raise ValueError(f"Unsupported workspace location mode: {mode}")
+
+
+def _normalize_relative_path(relative_path: str) -> str:
+    """Normalize a client relative path into a safe POSIX-like representation."""
+    if not relative_path:
+        return ""
+    cleaned = relative_path.replace("\\", "/").strip("/")
+    path = PurePosixPath(cleaned)
+    if any(part in {"..", "."} for part in path.parts):
+        raise ValueError("Relative path traversal is not allowed.")
+    return path.as_posix()
+
+
+def _resolve_child_path(root: Path, relative_path: str) -> Path:
+    """Resolve a client-supplied relative path under a validated root."""
+    normalized = _normalize_relative_path(relative_path)
+    candidate = (root / Path(normalized)).resolve() if normalized else root.resolve()
+    if not candidate.is_relative_to(root.resolve()):
+        raise ValueError("Requested path escapes the configured workspace root.")
+    return candidate
+
+
+def detect_entry_kind(path: Path) -> str:
+    """Classify a filesystem entry into a Haptic Desktop content kind."""
+    if path.is_dir():
+        return "directory"
+    suffix = path.suffix.lower()
+    if suffix in SUPPORTED_MODEL_SUFFIXES:
+        return "model"
+    if suffix in SUPPORTED_TEXT_SUFFIXES:
+        return "text"
+    if suffix in SUPPORTED_AUDIO_SUFFIXES:
+        return "audio"
+    return "unsupported"
+
+
+def _read_workspace_descriptor(path: Path) -> dict[str, Any]:
+    """Load and minimally validate a workspace descriptor file."""
+    descriptor = json.loads(path.read_text(encoding="utf-8"))
+    if descriptor.get("format") != WORKSPACE_FORMAT:
+        raise ValueError(f"Unsupported workspace format in {path.name}.")
+    if descriptor.get("format_version") != 1:
+        raise ValueError(f"Unsupported workspace format_version in {path.name}.")
+    if not descriptor.get("slug") or not descriptor.get("title"):
+        raise ValueError(f"Workspace descriptor {path.name} is missing required title/slug fields.")
+    return descriptor
+
+
+def _load_workspace_record(path: Path, *, registry_source: str) -> dict[str, Any]:
+    """Return a resolved catalog record for one workspace descriptor file."""
+    descriptor = _read_workspace_descriptor(path)
+    content_root = _resolve_location(path, descriptor["content_root"])
+    file_browser_root = _resolve_location(path, descriptor["file_browser_root"])
+    if not content_root.exists():
+        raise ValueError(f"Workspace content root does not exist for {path.name}.")
+    if not file_browser_root.exists():
+        raise ValueError(f"Workspace file-browser root does not exist for {path.name}.")
+
+    libraries = descriptor.get("libraries", {})
+    return {
+        "slug": descriptor["slug"],
+        "title": descriptor["title"],
+        "description": descriptor.get("description", ""),
+        "is_default": bool(descriptor.get("is_default")),
+        "registry_source": registry_source,
+        "workspace_file_path": str(path.resolve()),
+        "content_root": content_root,
+        "file_browser_root": file_browser_root,
+        "libraries": libraries,
+    }
+
+
+def _workspace_records() -> list[dict[str, Any]]:
+    """Return all known workspaces, including the bundled demo workspace."""
+    records: list[dict[str, Any]] = []
+    seen_paths: set[Path] = set()
+    demo_path = DEMO_WORKSPACE_FILE.resolve()
+    if demo_path.exists():
+        records.append(_load_workspace_record(demo_path, registry_source="bundled_demo"))
+        seen_paths.add(demo_path)
+
+    registry_payload = _load_registry_payload()
+    for raw_path in registry_payload.get("workspace_files", []):
+        path = Path(raw_path).expanduser().resolve()
+        if path in seen_paths or not path.exists():
+            continue
+        try:
+            records.append(_load_workspace_record(path, registry_source="user_registered"))
+            seen_paths.add(path)
+        except ValueError:
+            continue
+    return records
+
+
+def _workspace_record_by_slug(slug: str) -> dict[str, Any]:
+    """Return one workspace record by slug."""
+    for record in _workspace_records():
+        if record["slug"] == slug:
+            return record
+    raise KeyError(slug)
+
+
+def _catalog_lookup(items: list[dict[str, Any]], key: str, value: str) -> dict[str, Any] | None:
+    """Return one catalog item by a selected key value."""
+    return next((item for item in items if item.get(key) == value), None)
+
+
+def _resolve_workspace_item(workspace_slug: str, record: dict[str, Any], category: str, item: dict[str, Any]) -> dict[str, Any]:
+    """Resolve one workspace item into a frontend-ready payload."""
+    source = item.get("source", {})
+    source_kind = source.get("kind")
+    ref = source.get("ref")
+    payload = {
+        "slug": item["slug"],
+        "title": item["title"],
+        "summary": item.get("summary", ""),
+        "category": category,
+        "source": {"kind": source_kind},
+    }
+
+    if source_kind == "demo_model":
+        model = _catalog_lookup(build_demo_model_catalog(), "slug", ref)
+        if model is None:
+            raise ValueError(f"Unknown demo model reference: {ref}")
+        payload["kind"] = "model"
+        payload["source"].update(
+            {
+                "ref": ref,
+                "demo_model_slug": model["slug"],
+                "file_url": model["file_url"],
+                "title": model["title"],
+            },
+        )
+        return payload
+
+    if source_kind == "library_document":
+        document = _catalog_lookup(build_document_catalog(), "slug", ref)
+        if document is None:
+            raise ValueError(f"Unknown library document reference: {ref}")
+        payload["kind"] = "text"
+        payload["source"].update(
+            {
+                "ref": ref,
+                "document_slug": document["slug"],
+                "text_endpoint": f"/api/library/documents/{document['slug']}",
+                "format": document["format"],
+            },
+        )
+        return payload
+
+    if source_kind == "library_audio":
+        audio = _catalog_lookup(build_audio_catalog(), "slug", ref)
+        if audio is None:
+            raise ValueError(f"Unknown library audio reference: {ref}")
+        payload["kind"] = "audio"
+        payload["source"].update(
+            {
+                "ref": ref,
+                "audio_slug": audio["slug"],
+                "file_url": audio["file_url"],
+                "format": audio["format"],
+            },
+        )
+        return payload
+
+    if source_kind == "workspace_file":
+        relative_path = _normalize_relative_path(source.get("relative_path", ""))
+        file_path = _resolve_child_path(record["content_root"], relative_path)
+        payload["kind"] = detect_entry_kind(file_path)
+        payload["source"].update(
+            {
+                "relative_path": relative_path,
+                "raw_file_endpoint": f"/api/haptic-workspaces/{workspace_slug}/raw-file?path={relative_path}",
+            },
+        )
+        if payload["kind"] == "text":
+            payload["source"]["text_endpoint"] = (
+                f"/api/haptic-workspaces/{workspace_slug}/text-file?path={relative_path}"
+            )
+        return payload
+
+    raise ValueError(f"Unsupported workspace source kind: {source_kind}")
+
+
+def build_haptic_workspace_catalog() -> list[dict[str, Any]]:
+    """Return the public catalog of available Haptic Desktop workspaces."""
+    catalog: list[dict[str, Any]] = []
+    for record in _workspace_records():
+        catalog.append(
+            {
+                "slug": record["slug"],
+                "title": record["title"],
+                "description": record["description"],
+                "is_default": record["is_default"],
+                "registry_source": record["registry_source"],
+                "workspace_file_path": record["workspace_file_path"],
+                "category_counts": {
+                    "models": len(record["libraries"].get("models", [])),
+                    "texts": len(record["libraries"].get("texts", [])),
+                    "audio": len(record["libraries"].get("audio", [])),
+                },
+            },
+        )
+    return catalog
+
+
+def build_haptic_workspace_payload(slug: str) -> dict[str, Any]:
+    """Return one resolved workspace payload for frontend scene generation."""
+    record = _workspace_record_by_slug(slug)
+    libraries = {}
+    for category in ("models", "texts", "audio"):
+        libraries[category] = [
+            _resolve_workspace_item(slug, record, category, item)
+            for item in record["libraries"].get(category, [])
+        ]
+
+    return {
+        "slug": record["slug"],
+        "title": record["title"],
+        "description": record["description"],
+        "is_default": record["is_default"],
+        "registry_source": record["registry_source"],
+        "workspace_file_path": record["workspace_file_path"],
+        "libraries": libraries,
+        "file_browser": {
+            "root_label": record["file_browser_root"].name,
+            "root_path_hint": str(record["file_browser_root"]),
+        },
+    }
+
+
+def build_workspace_browser_payload(slug: str, relative_path: str = "") -> dict[str, Any]:
+    """Return a safe file-system browser payload under the configured root."""
+    record = _workspace_record_by_slug(slug)
+    current_directory = _resolve_child_path(record["file_browser_root"], relative_path)
+    if not current_directory.is_dir():
+        raise ValueError("Requested workspace browser path is not a directory.")
+
+    normalized_path = _normalize_relative_path(relative_path)
+    entries: list[dict[str, Any]] = []
+    for child in sorted(current_directory.iterdir(), key=lambda path: (not path.is_dir(), path.name.lower())):
+        child_relative = child.relative_to(record["file_browser_root"]).as_posix()
+        kind = detect_entry_kind(child)
+        entry = {
+            "slug": _slugify(child_relative),
+            "title": child.name,
+            "summary": f"{kind.title()} entry in the configured workspace root.",
+            "kind": kind,
+            "relative_path": child_relative,
+            "size_bytes": child.stat().st_size if child.is_file() else 0,
+        }
+        if kind == "directory":
+            entry["child_count"] = sum(1 for _ in child.iterdir())
+        else:
+            entry["source"] = {
+                "kind": "workspace_file",
+                "relative_path": child_relative,
+                "raw_file_endpoint": f"/api/haptic-workspaces/{slug}/raw-file?path={child_relative}",
+            }
+            if kind == "text":
+                entry["source"]["text_endpoint"] = (
+                    f"/api/haptic-workspaces/{slug}/text-file?path={child_relative}"
+                )
+        entries.append(entry)
+
+    parent_path = ""
+    if normalized_path:
+        parent_path = PurePosixPath(normalized_path).parent.as_posix()
+        if parent_path == ".":
+            parent_path = ""
+
+    return {
+        "workspace_slug": slug,
+        "current_path": normalized_path,
+        "current_label": current_directory.name,
+        "parent_path": parent_path or None,
+        "entries": entries,
+    }
+
+
+def raw_workspace_file_path(slug: str, relative_path: str) -> Path:
+    """Return a safe raw file path rooted in the workspace browser root."""
+    record = _workspace_record_by_slug(slug)
+    candidate = _resolve_child_path(record["file_browser_root"], relative_path)
+    if not candidate.is_file():
+        raise ValueError("Requested workspace file does not exist.")
+    return candidate
+
+
+def build_workspace_text_payload(slug: str, relative_path: str, *, offset: int = 0, max_chars: int = DEFAULT_SEGMENT_CHARS) -> dict[str, Any]:
+    """Return a segmented text payload for one raw workspace file."""
+    file_path = raw_workspace_file_path(slug, relative_path)
+    if detect_entry_kind(file_path) != "text":
+        raise ValueError("Requested workspace file is not a supported text file.")
+    return build_text_payload_from_path(
+        file_path,
+        title=file_path.name,
+        source_name="Workspace file",
+        source_url=file_path.as_posix(),
+        offset=offset,
+        max_chars=max_chars,
+    )
+
+
+def register_workspace_file(workspace_file_path: str) -> dict[str, Any]:
+    """Register an existing workspace descriptor file in the local registry."""
+    path = Path(workspace_file_path).expanduser().resolve()
+    if not path.exists() or not path.is_file():
+        raise ValueError("Workspace file path does not exist.")
+    if path.suffixes[-2:] != [".haptic_workspace", ".json"] and not path.name.endswith(WORKSPACE_SUFFIX):
+        raise ValueError(f"Workspace files must end with {WORKSPACE_SUFFIX}.")
+
+    descriptor = _read_workspace_descriptor(path)
+    existing_slugs = {record["slug"] for record in _workspace_records()}
+    if descriptor["slug"] in existing_slugs and path.resolve() != DEMO_WORKSPACE_FILE.resolve():
+        for record in _workspace_records():
+            if record["slug"] == descriptor["slug"] and Path(record["workspace_file_path"]).resolve() != path:
+                raise ValueError(f"A workspace with slug '{descriptor['slug']}' is already registered.")
+
+    payload = _load_registry_payload()
+    paths = {Path(item).expanduser().resolve() for item in payload.get("workspace_files", [])}
+    paths.add(path)
+    payload["workspace_files"] = [str(item) for item in sorted(paths)]
+    _save_registry_payload(payload)
+    return _load_workspace_record(path, registry_source="user_registered")
+
+
+def _auto_collect_workspace_items(root_path: Path, kind: str) -> list[dict[str, Any]]:
+    """Discover workspace files of a given kind under a user root."""
+    suffixes = {
+        "models": SUPPORTED_MODEL_SUFFIXES,
+        "texts": SUPPORTED_TEXT_SUFFIXES,
+        "audio": SUPPORTED_AUDIO_SUFFIXES,
+    }[kind]
+
+    items: list[dict[str, Any]] = []
+    for path in sorted(root_path.rglob("*"), key=lambda entry: entry.as_posix().lower()):
+        if not path.is_file() or path.name.endswith(WORKSPACE_SUFFIX):
+            continue
+        if path.suffix.lower() not in suffixes:
+            continue
+        relative_path = path.relative_to(root_path).as_posix()
+        items.append(
+            {
+                "slug": _slugify(relative_path),
+                "title": path.stem.replace("_", " ").replace("-", " ").title(),
+                "summary": f"Auto-discovered {kind[:-1]} from the workspace root.",
+                "source": {"kind": "workspace_file", "relative_path": relative_path},
+            },
+        )
+    return items
+
+
+def create_workspace_file(
+    *,
+    title: str,
+    slug: str | None,
+    description: str,
+    root_path: str,
+    auto_populate: bool = True,
+) -> dict[str, Any]:
+    """Create, register, and return a new workspace descriptor rooted in a user folder."""
+    workspace_root = Path(root_path).expanduser().resolve()
+    if not workspace_root.exists() or not workspace_root.is_dir():
+        raise ValueError("Workspace root path must be an existing directory.")
+
+    workspace_slug = _slugify(slug or title)
+    workspace_file_path = workspace_root / f"{workspace_slug}{WORKSPACE_SUFFIX}"
+    if workspace_file_path.exists():
+        raise ValueError(f"The workspace file already exists: {workspace_file_path.name}")
+
+    descriptor = {
+        "format": WORKSPACE_FORMAT,
+        "format_version": 1,
+        "slug": workspace_slug,
+        "title": title,
+        "description": description,
+        "is_default": False,
+        "content_root": {"mode": "absolute", "path": str(workspace_root)},
+        "file_browser_root": {"mode": "absolute", "path": str(workspace_root)},
+        "libraries": {
+            "models": _auto_collect_workspace_items(workspace_root, "models") if auto_populate else [],
+            "texts": _auto_collect_workspace_items(workspace_root, "texts") if auto_populate else [],
+            "audio": _auto_collect_workspace_items(workspace_root, "audio") if auto_populate else [],
+        },
+    }
+    workspace_file_path.write_text(json.dumps(descriptor, indent=2), encoding="utf-8")
+    return register_workspace_file(str(workspace_file_path))
+
+
+def build_workspace_manager_payload() -> dict[str, Any]:
+    """Return workspace-manager metadata for the frontend page."""
+    return {
+        "workspace_suffix": WORKSPACE_SUFFIX,
+        "registry_file_path": str(REGISTRY_FILE),
+        "workspaces": build_haptic_workspace_catalog(),
+    }

--- a/app/core/library_assets.py
+++ b/app/core/library_assets.py
@@ -339,6 +339,18 @@ def _extract_epub_text(path: Path) -> str:
     return _normalize_text(_strip_gutenberg_boilerplate("\n\n".join(parts)))
 
 
+def extract_document_text_from_path(path: Path) -> str:
+    """Extract readable text from a supported document path."""
+    suffix = path.suffix.lower()
+    if suffix == ".txt" or suffix == ".md":
+        return _extract_txt_text(path)
+    if suffix in {".html", ".htm"}:
+        return _extract_html_file_text(path)
+    if suffix == ".epub":
+        return _extract_epub_text(path)
+    raise ValueError(f"Unsupported document format: {path.suffix}")
+
+
 @lru_cache(maxsize=None)
 def read_document_text(slug: str) -> str:
     """Return the fully extracted text for a known bundled document."""
@@ -347,14 +359,7 @@ def read_document_text(slug: str) -> str:
         raise KeyError(slug)
 
     path = DOCUMENTS_DIR / document.filename
-    suffix = path.suffix.lower()
-    if suffix == ".txt":
-        return _extract_txt_text(path)
-    if suffix in {".html", ".htm"}:
-        return _extract_html_file_text(path)
-    if suffix == ".epub":
-        return _extract_epub_text(path)
-    raise ValueError(f"Unsupported document format: {path.suffix}")
+    return extract_document_text_from_path(path)
 
 
 def _clip_excerpt(text: str, offset: int, max_chars: int) -> tuple[str, int, int]:
@@ -391,6 +396,46 @@ def build_audio_catalog() -> list[dict[str, object]]:
         payload["file_size_bytes"] = _asset_file_size(AUDIO_DIR / audio.filename)
         catalog.append(payload)
     return catalog
+
+
+def build_text_payload_from_path(
+    path: Path,
+    *,
+    title: str,
+    source_name: str,
+    source_url: str,
+    offset: int = 0,
+    max_chars: int = 1200,
+) -> dict[str, object]:
+    """Return a clipped text payload for a supported arbitrary document path."""
+    text = extract_document_text_from_path(path)
+    excerpt, start, end = _clip_excerpt(text, offset, max_chars)
+    return {
+        "slug": _slugify_path(path),
+        "title": title,
+        "author": "Unknown",
+        "format": path.suffix.lower().lstrip("."),
+        "filename": path.name,
+        "file_url": "",
+        "source_name": source_name,
+        "source_url": source_url,
+        "summary": f"Text content loaded from {path.name}.",
+        "recommended_excerpt_chars": max_chars,
+        "companion_audio_slugs": (),
+        "file_size_bytes": _asset_file_size(path),
+        "text": excerpt,
+        "offset": start,
+        "next_offset": end if end < len(text) else None,
+        "previous_offset": max(0, start - max_chars) if start > 0 else None,
+        "loaded_characters": len(excerpt),
+        "total_characters": len(text),
+        "has_more": end < len(text),
+    }
+
+
+def _slugify_path(path: Path) -> str:
+    """Convert a filesystem path into a stable slug."""
+    return re.sub(r"[^a-z0-9]+", "_", path.stem.lower()).strip("_") or "document"
 
 
 def build_document_payload(slug: str, *, offset: int = 0, max_chars: int | None = None) -> dict[str, object]:

--- a/app/core/modes.py
+++ b/app/core/modes.py
@@ -36,4 +36,14 @@ def build_mode_catalog() -> list[dict[str, object]]:
                 "future haptic interaction with digital content."
             ),
         },
+        {
+            "slug": "haptic-workspace-manager",
+            "route": "/haptic-workspace-manager",
+            "title": "Haptic Workspace Manager",
+            "status": "active",
+            "summary": (
+                "Management workspace for creating, registering, and inspecting structured "
+                "Haptic Desktop workspaces rooted in external user folders."
+            ),
+        },
     ]

--- a/app/core/version.py
+++ b/app/core/version.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 APP_NAME = "FeelIT"
-APP_VERSION = "0.4.0"
+APP_VERSION = "0.5.0"
 APP_PUBLISHER = "Felipe Santibanez"
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -72,4 +72,10 @@ async def haptic_desktop_page() -> FileResponse:
     return serve_static_page("haptic_desktop.html")
 
 
+@app.get("/haptic-workspace-manager", include_in_schema=False)
+async def haptic_workspace_manager_page() -> FileResponse:
+    """Serve the haptic workspace management page."""
+    return serve_static_page("haptic_workspace_manager.html")
+
+
 app.mount("/static", StaticFiles(directory=static_dir), name="static")

--- a/app/static/assets/workspaces/feelit_demo.haptic_workspace.json
+++ b/app/static/assets/workspaces/feelit_demo.haptic_workspace.json
@@ -1,0 +1,96 @@
+{
+  "format": "feelit_haptic_workspace",
+  "format_version": 1,
+  "slug": "feelit_demo_workspace",
+  "title": "FeelIT Demo Workspace",
+  "description": "Curated launcher workspace that combines demo models, bundled documents, bundled audio, and a controlled file-browser root for internal demonstrations.",
+  "is_default": true,
+  "content_root": {
+    "mode": "app_static_relative",
+    "path": "assets"
+  },
+  "file_browser_root": {
+    "mode": "app_static_relative",
+    "path": "assets/library"
+  },
+  "libraries": {
+    "models": [
+      {
+        "slug": "walt_head_session",
+        "title": "Walt Head",
+        "summary": "Contour-rich sculpture for introductory tactile exploration.",
+        "source": {
+          "kind": "demo_model",
+          "ref": "walt_head"
+        }
+      },
+      {
+        "slug": "terrain_peak_session",
+        "title": "Terrain Peak",
+        "summary": "Topographic relief sample for slope and landscape interpretation.",
+        "source": {
+          "kind": "demo_model",
+          "ref": "terrain_peak"
+        }
+      },
+      {
+        "slug": "open_book_session",
+        "title": "Open Book",
+        "summary": "Reading-adjacent object for page, spine, and surface transitions.",
+        "source": {
+          "kind": "demo_model",
+          "ref": "open_book"
+        }
+      }
+    ],
+    "texts": [
+      {
+        "slug": "alice_reader_session",
+        "title": "Alice in Wonderland",
+        "summary": "Narrative reading sample with segmented tactile access.",
+        "source": {
+          "kind": "library_document",
+          "ref": "alice_in_wonderland_txt"
+        }
+      },
+      {
+        "slug": "pride_reader_session",
+        "title": "Pride and Prejudice",
+        "summary": "Long-form prose sample for multi-segment reading sessions.",
+        "source": {
+          "kind": "library_document",
+          "ref": "pride_and_prejudice_txt"
+        }
+      },
+      {
+        "slug": "raven_reader_session",
+        "title": "The Raven",
+        "summary": "Short HTML poem sample for quick tactile reading flows.",
+        "source": {
+          "kind": "library_document",
+          "ref": "the_raven_html"
+        }
+      }
+    ],
+    "audio": [
+      {
+        "slug": "alice_audio_session",
+        "title": "Alice Chapter One",
+        "summary": "Companion narration from the bundled internal library.",
+        "source": {
+          "kind": "library_audio",
+          "ref": "alice_chapter_01"
+        }
+      },
+      {
+        "slug": "raven_audio_session",
+        "title": "The Raven Audio",
+        "summary": "Short-form spoken-poetry sample for audio-scene controls.",
+        "source": {
+          "kind": "library_audio",
+          "ref": "the_raven_librivox"
+        }
+      }
+    ]
+  }
+}

--- a/app/static/braille_reader.html
+++ b/app/static/braille_reader.html
@@ -17,6 +17,7 @@
         <a class="mode-link" href="/object-explorer">3D Object Explorer</a>
         <a class="mode-link is-active" href="/braille-reader">Braille Reader</a>
         <a class="mode-link" href="/haptic-desktop">Haptic Desktop</a>
+        <a class="mode-link" href="/haptic-workspace-manager">Workspace Manager</a>
       </nav>
       <div class="header-tools">
         <span class="version-badge" data-runtime="version">v--</span>

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -180,6 +180,10 @@ a {
   gap: 0;
 }
 
+.workspace-panel-scroll {
+  overflow-y: auto;
+}
+
 .panel-section {
   border-radius: 12px;
   border: 1px solid var(--border);
@@ -343,6 +347,12 @@ input[type="range"] {
 
 .btn-secondary:hover {
   background: rgba(88, 166, 255, 0.22);
+}
+
+.btn-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .btn:disabled {
@@ -699,6 +709,59 @@ input[type="range"] {
   filter: saturate(0.82) brightness(0.92);
 }
 
+.manager-surface {
+  display: grid;
+  gap: 14px;
+  padding: 14px;
+}
+
+.manager-summary-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.workspace-list {
+  display: grid;
+  gap: 10px;
+}
+
+.workspace-card {
+  display: grid;
+  gap: 8px;
+  width: 100%;
+  padding: 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(48, 54, 61, 0.9);
+  background: rgba(13, 17, 23, 0.88);
+  color: var(--text-primary);
+  text-align: left;
+  cursor: pointer;
+}
+
+.workspace-card:hover,
+.workspace-card.is-selected {
+  border-color: rgba(57, 210, 192, 0.42);
+  box-shadow: 0 0 0 1px rgba(57, 210, 192, 0.12);
+}
+
+.workspace-card-title {
+  color: var(--text-primary);
+  font-size: 0.92rem;
+}
+
+.workspace-card-body,
+.workspace-card-meta,
+.workspace-card-path {
+  color: var(--text-secondary);
+  line-height: 1.5;
+  font-size: 0.82rem;
+}
+
+.workspace-card-path {
+  word-break: break-word;
+  font-family: "Consolas", "Courier New", monospace;
+  font-size: 0.76rem;
+}
+
 .modal {
   display: none;
   position: fixed;
@@ -845,5 +908,9 @@ input[type="range"] {
   .subsurface-header {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .manager-summary-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/app/static/haptic_desktop.html
+++ b/app/static/haptic_desktop.html
@@ -17,6 +17,7 @@
         <a class="mode-link" href="/object-explorer">3D Object Explorer</a>
         <a class="mode-link" href="/braille-reader">Braille Reader</a>
         <a class="mode-link is-active" href="/haptic-desktop">Haptic Desktop</a>
+        <a class="mode-link" href="/haptic-workspace-manager">Workspace Manager</a>
       </nav>
       <div class="header-tools">
         <span class="version-badge" data-runtime="version">v--</span>
@@ -28,39 +29,57 @@
       <aside class="control-panel">
         <section class="panel-section">
           <div class="section-header">
-            <h2>Layout And Debug</h2>
+            <h2>Workspace</h2>
           </div>
-          <label for="layout-preset">Layout preset</label>
-          <select id="layout-preset">
-            <option value="grid" selected>Grid workspace</option>
-            <option value="arc">Arc launcher</option>
-            <option value="cluster">Clustered desk</option>
-          </select>
+          <label for="desktop-workspace-select">Active haptic workspace</label>
+          <select id="desktop-workspace-select"></select>
+          <div class="button-row">
+            <button id="load-desktop-workspace" class="btn btn-primary" type="button">Load Workspace</button>
+            <a class="btn btn-secondary btn-link" href="/haptic-workspace-manager">Open Manager</a>
+          </div>
+          <div class="status-stack">
+            <div class="status-card">
+              <span class="status-label">Current workspace</span>
+              <span id="desktop-workspace-title" class="status-value">Loading</span>
+            </div>
+            <div class="status-card">
+              <span class="status-label">Scene</span>
+              <span id="desktop-scene-code" class="status-value">launcher</span>
+            </div>
+          </div>
+        </section>
+
+        <section class="panel-section">
+          <div class="section-header">
+            <h2>Runtime Controls</h2>
+          </div>
+          <label for="desktop-text-segment-size">Text segment size</label>
+          <input id="desktop-text-segment-size" type="number" min="300" max="4000" value="1200">
           <label class="toggle-row">
             <input id="audio-cues-toggle" type="checkbox" checked>
-            <span>Enable audio cue labels</span>
+            <span>Enable spoken cue announcements</span>
           </label>
           <label class="toggle-row">
             <input id="pointer-toggle" type="checkbox" checked>
             <span>Show pointer proxy</span>
           </label>
           <p class="panel-text">
-            The desktop objects inside the 3D world are the primary interaction surface. The buttons below are a fallback debug path.
+            The controls inside the 3D world are the primary path. The buttons below remain as a fallback debug path while the workspace scenes become richer.
           </p>
           <div class="button-row">
-            <button id="focus-prev" class="btn btn-secondary" type="button">Focus Previous (Fallback)</button>
-            <button id="focus-next" class="btn btn-secondary" type="button">Focus Next (Fallback)</button>
-            <button id="focus-activate" class="btn btn-primary" type="button">Activate (Fallback)</button>
+            <button id="focus-prev" class="btn btn-secondary" type="button">Focus Previous</button>
+            <button id="focus-next" class="btn btn-secondary" type="button">Focus Next</button>
+            <button id="focus-activate" class="btn btn-primary" type="button">Activate Focus</button>
           </div>
         </section>
 
         <section class="panel-section">
           <div class="section-header">
-            <h2>Navigation</h2>
+            <h2>Desktop Intent</h2>
           </div>
           <p class="panel-text">
-            The visible 3D desk is the intended interaction world. The focused item is highlighted,
-            and the pointer proxy moves to the current object target.
+            The Haptic Desktop is no longer a single static desk. It is a workspace-driven scene system where the launcher, galleries,
+            file-browser, and opened content each become their own tactile 3D world.
           </p>
         </section>
       </aside>
@@ -69,18 +88,19 @@
         <div class="panel-heading">
           <div>
             <h2>Virtual Desktop Workspace</h2>
-            <p class="panel-subtitle">3D object-based desktop scene for folders, media, settings, and assistive actions.</p>
+            <p id="desktop-scene-subtitle" class="panel-subtitle">Workspace-driven launcher, galleries, and opened-content scenes for blind-first exploration.</p>
           </div>
           <div class="panel-heading-status">
-            <span id="desktop-runtime-pill" class="status-pill status-pill-purple">Prototype workspace</span>
-            <span id="desktop-page-status" class="status-pill">Ready</span>
+            <span id="desktop-runtime-pill" class="status-pill status-pill-purple">Workspace loading</span>
+            <span id="desktop-page-status" class="status-pill">Waiting</span>
           </div>
         </div>
 
         <div class="workspace-stage stage-3d">
           <canvas id="desktop-canvas" class="stage-canvas"></canvas>
           <div class="stage-overlay top-left telemetry-row">
-            <span class="telemetry-chip">Focus <strong id="desktop-focus-count">1 / 6</strong></span>
+            <span class="telemetry-chip">Workspace <strong id="desktop-workspace-chip">--</strong></span>
+            <span class="telemetry-chip">Scene <strong id="desktop-scene-chip">--</strong></span>
             <span class="telemetry-chip">Audio <strong id="desktop-audio-state">On</strong></span>
             <span class="telemetry-chip">Backend <strong data-runtime="backend">--</strong></span>
           </div>
@@ -92,6 +112,7 @@
           <div class="stage-overlay bottom-left">
             <span id="desktop-status-bar" class="stage-statusbar">Desktop workspace ready.</span>
           </div>
+          <audio id="desktop-audio-player" preload="none"></audio>
         </div>
       </section>
 
@@ -110,6 +131,18 @@
 
         <section class="panel-section">
           <div class="section-header">
+            <h2>Scene State</h2>
+          </div>
+          <dl class="info-grid">
+            <div><dt>Scene</dt><dd id="desktop-scene-label">--</dd></div>
+            <div><dt>Context</dt><dd id="desktop-scene-context">--</dd></div>
+            <div><dt>Path</dt><dd id="desktop-scene-path">--</dd></div>
+            <div><dt>Pagination</dt><dd id="desktop-pagination">--</dd></div>
+          </dl>
+        </section>
+
+        <section class="panel-section">
+          <div class="section-header">
             <h2>Focused Object</h2>
           </div>
           <dl class="info-grid">
@@ -121,9 +154,21 @@
 
         <section class="panel-section">
           <div class="section-header">
+            <h2>Audio Session</h2>
+          </div>
+          <dl class="info-grid">
+            <div><dt>Track</dt><dd id="desktop-audio-track">--</dd></div>
+            <div><dt>Playback</dt><dd id="desktop-audio-playback">idle</dd></div>
+            <div><dt>Position</dt><dd id="desktop-audio-position">0.0 s</dd></div>
+            <div><dt>Duration</dt><dd id="desktop-audio-duration">--</dd></div>
+          </dl>
+        </section>
+
+        <section class="panel-section">
+          <div class="section-header">
             <h2>Announcement</h2>
           </div>
-          <p id="desktop-announcement" class="panel-text">Loading desktop objects.</p>
+          <p id="desktop-announcement" class="panel-text">Loading desktop workspace.</p>
         </section>
       </aside>
     </main>
@@ -138,14 +183,21 @@
       <div class="modal-body">
         <h3>Purpose</h3>
         <p>
-          This workspace prototypes a 3D desktop made of touchable objects. The visible desk is the
-          intended world for future haptic navigation and activation.
+          This mode is a workspace-driven tactile desktop. It starts from a structured `haptic_workspace`, then moves the user through a 3D launcher,
+          paginated content galleries, file-system navigation, and opened scenes for models, audio, and text.
         </p>
         <h3>Current Interaction</h3>
         <ul>
-          <li>Move the pointer emulator through the desktop world with `W`, `A`, `S`, `D`, `Q`, and `E`.</li>
-          <li>Let the pointer hover a desktop object to focus it, then activate it with `Space` or `Enter`.</li>
-          <li>Change the layout preset to test different spatial arrangements.</li>
+          <li>Select the active workspace from the left panel, then load it into the scene engine.</li>
+          <li>Move the pointer emulator with `W`, `A`, `S`, `D`, `Q`, and `E` and activate focused objects with `Space` or `Enter`.</li>
+          <li>Use tactile scene controls for home, back, paging, opening content, and browsing the workspace file root.</li>
+          <li>Use spoken cues as a support channel while keeping the object shapes and scene changes as the primary interaction contract.</li>
+        </ul>
+        <h3>Current Limits</h3>
+        <ul>
+          <li>The workspace-driven desktop is still a modern rebuild, not a recovered legacy implementation.</li>
+          <li>The initial content-opening paths are designed to prove the interaction model before a native haptic backend is attached.</li>
+          <li>User workspaces are rooted in external folders on disk so large assets do not need to live inside the application repository.</li>
         </ul>
       </div>
     </div>

--- a/app/static/haptic_workspace_manager.html
+++ b/app/static/haptic_workspace_manager.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>FeelIT | Haptic Workspace Manager</title>
+  <link rel="stylesheet" href="/static/css/style.css">
+</head>
+<body data-page="haptic-workspace-manager">
+  <div class="app-shell">
+    <header class="app-header">
+      <div class="title-group">
+        <h1>FeelIT</h1>
+        <p class="subtitle">Accessible haptic interaction platform</p>
+      </div>
+      <nav class="mode-nav" aria-label="FeelIT modes">
+        <a class="mode-link" href="/object-explorer">3D Object Explorer</a>
+        <a class="mode-link" href="/braille-reader">Braille Reader</a>
+        <a class="mode-link" href="/haptic-desktop">Haptic Desktop</a>
+        <a class="mode-link is-active" href="/haptic-workspace-manager">Workspace Manager</a>
+      </nav>
+      <div class="header-tools">
+        <span class="version-badge" data-runtime="version">v--</span>
+        <button class="help-btn" type="button" data-open-modal="help-modal" aria-label="Open help">?</button>
+      </div>
+    </header>
+
+    <main class="workspace-grid">
+      <aside class="control-panel">
+        <section class="panel-section">
+          <div class="section-header">
+            <h2>Create Workspace</h2>
+          </div>
+          <label for="workspace-title">Workspace title</label>
+          <input id="workspace-title" type="text" value="My Haptic Workspace">
+          <label for="workspace-slug">Workspace slug</label>
+          <input id="workspace-slug" type="text" placeholder="Optional; auto-generated when empty">
+          <label for="workspace-root-path">External root folder</label>
+          <input id="workspace-root-path" type="text" placeholder="D:\Media\AccessibleWorkspace">
+          <label for="workspace-description">Description</label>
+          <textarea id="workspace-description" rows="6">External workspace rooted in a user-controlled folder. Large assets stay outside the app repository.</textarea>
+          <label class="toggle-row">
+            <input id="workspace-auto-populate" type="checkbox" checked>
+            <span>Auto-populate model, text, and audio libraries from the root folder</span>
+          </label>
+          <div class="button-row">
+            <button id="create-workspace" class="btn btn-primary" type="button">Create Workspace</button>
+            <button id="refresh-workspaces" class="btn btn-secondary" type="button">Refresh</button>
+          </div>
+        </section>
+
+        <section class="panel-section">
+          <div class="section-header">
+            <h2>Register Existing</h2>
+          </div>
+          <label for="existing-workspace-path">Workspace file path</label>
+          <input id="existing-workspace-path" type="text" placeholder="D:\Media\MyWorkspace\my_workspace.haptic_workspace.json">
+          <div class="button-row">
+            <button id="register-workspace" class="btn btn-primary" type="button">Register Workspace</button>
+          </div>
+          <p class="panel-text">
+            Use this path when the workspace file already exists on disk and you only need FeelIT to register it locally.
+          </p>
+        </section>
+      </aside>
+
+      <section class="workspace-panel workspace-panel-scroll">
+        <div class="panel-heading">
+          <div>
+            <h2>Known Workspaces</h2>
+            <p class="panel-subtitle">Structured desktop workspaces registered for Haptic Desktop. Bundled demo first, user workspaces after that.</p>
+          </div>
+          <div class="panel-heading-status">
+            <span id="manager-runtime-pill" class="status-pill status-pill-cyan">Loading</span>
+            <span id="manager-page-status" class="status-pill">Waiting</span>
+          </div>
+        </div>
+
+        <div class="manager-surface">
+          <div class="subsurface-panel">
+            <div class="subsurface-header">
+              <h3>Registry Summary</h3>
+              <span class="subsurface-note">The registry stores workspace file references, not heavy media payloads.</span>
+            </div>
+            <div class="status-stack manager-summary-grid">
+              <div class="status-card">
+                <span class="status-label">Known workspaces</span>
+                <span id="workspace-count" class="status-value">0</span>
+              </div>
+              <div class="status-card">
+                <span class="status-label">Workspace suffix</span>
+                <span id="workspace-suffix" class="status-value">Loading</span>
+              </div>
+              <div class="status-card">
+                <span class="status-label">Registry path</span>
+                <span id="workspace-registry-path" class="status-value">Loading</span>
+              </div>
+            </div>
+          </div>
+
+          <section class="panel-section">
+            <div class="section-header">
+              <h2>Workspace Catalog</h2>
+            </div>
+            <div id="workspace-list" class="workspace-list"></div>
+          </section>
+        </div>
+      </section>
+
+      <aside class="inspector-panel">
+        <section class="panel-section">
+          <div class="section-header">
+            <h2>Runtime</h2>
+          </div>
+          <dl class="info-grid">
+            <div><dt>API</dt><dd data-runtime="api-status">Loading</dd></div>
+            <div><dt>Version</dt><dd data-runtime="version">Loading</dd></div>
+            <div><dt>Port</dt><dd data-runtime="port">Loading</dd></div>
+            <div><dt>Backend</dt><dd data-runtime="backend">Loading</dd></div>
+          </dl>
+        </section>
+
+        <section class="panel-section">
+          <div class="section-header">
+            <h2>Selected Workspace</h2>
+          </div>
+          <dl class="info-grid">
+            <div><dt>Title</dt><dd id="selected-workspace-title">--</dd></div>
+            <div><dt>Source</dt><dd id="selected-workspace-source">--</dd></div>
+            <div><dt>Models</dt><dd id="selected-workspace-models">--</dd></div>
+            <div><dt>Texts</dt><dd id="selected-workspace-texts">--</dd></div>
+            <div><dt>Audio</dt><dd id="selected-workspace-audio">--</dd></div>
+          </dl>
+        </section>
+
+        <section class="panel-section">
+          <div class="section-header">
+            <h2>Status</h2>
+          </div>
+          <p id="manager-status-bar" class="panel-text">Loading workspace registry.</p>
+        </section>
+      </aside>
+    </main>
+  </div>
+
+  <div id="help-modal" class="modal">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h2>Haptic Workspace Manager</h2>
+        <button class="modal-close" type="button" data-close-modal="help-modal" aria-label="Close help">&times;</button>
+      </div>
+      <div class="modal-body">
+        <h3>Purpose</h3>
+        <p>
+          This page manages structured desktop workspaces. A workspace file defines curated galleries and a safe file-browser root,
+          while the heavy media stays in an external folder on the user's machine.
+        </p>
+        <h3>Current Interaction</h3>
+        <ul>
+          <li>Create a new workspace rooted in an external folder.</li>
+          <li>Auto-populate that workspace from supported files already present in the chosen root.</li>
+          <li>Register an existing `.haptic_workspace.json` file.</li>
+          <li>Review the currently known workspaces before using them inside Haptic Desktop.</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="/static/js/haptic_workspace_manager.js"></script>
+</body>
+</html>

--- a/app/static/js/haptic_desktop.js
+++ b/app/static/js/haptic_desktop.js
@@ -1,197 +1,595 @@
 import { bootWorkspace } from "./app.js";
+import { OBJLoader } from "../vendor/three/OBJLoader.js";
 import {
   THREE,
   attachPointerEmulation,
+  createLabelSprite,
   createWorkspaceScene,
 } from "./three_scene_common.js";
 
-const desktopItems = [
-  {
-    slug: "models_library",
-    label: "Models Library",
-    type: "Folder",
-    action: "Open models library",
-    description: "Curated collection of tactile 3D objects.",
+const workspaceCatalogUrl = "/api/haptic-workspaces";
+const workspaceDetailUrl = (slug) => `/api/haptic-workspaces/${encodeURIComponent(slug)}`;
+const workspaceBrowseUrl = (slug, path = "") =>
+  `/api/haptic-workspaces/${encodeURIComponent(slug)}/browse?path=${encodeURIComponent(path)}`;
+const workspaceTextUrl = (slug, path, offset, maxChars) =>
+  `/api/haptic-workspaces/${encodeURIComponent(slug)}/text-file?path=${encodeURIComponent(path)}&offset=${offset}&max_chars=${maxChars}`;
+const workspaceRawUrl = (slug, path) =>
+  `/api/haptic-workspaces/${encodeURIComponent(slug)}/raw-file?path=${encodeURIComponent(path)}`;
+const braillePreviewUrl = "/api/braille/preview";
+
+const GALLERY_PAGE_SIZE = 6;
+const FILE_BROWSER_PAGE_SIZE = 6;
+const TEXT_COLUMNS = 8;
+const TEXT_ROWS_PER_PAGE = 4;
+const DETAIL_BRAILLE_COLUMNS = 10;
+const SEEK_SECONDS = 10;
+
+const CATEGORY_META = {
+  models: {
+    title: "Models Gallery",
+    sceneCode: "models-gallery",
     color: 0x58a6ff,
+    description: "Curated 3D models prepared for bounded tactile exploration.",
   },
-  {
-    slug: "braille_shelf",
-    label: "Braille Shelf",
-    type: "Reader",
-    action: "Open reading shelf",
-    description: "Entry point for tactile reading sessions.",
+  texts: {
+    title: "Text Library",
+    sceneCode: "texts-gallery",
     color: 0x7ee787,
+    description: "Curated text and book assets prepared for tactile Braille reading scenes.",
   },
-  {
-    slug: "audio_notes",
-    label: "Audio Notes",
-    type: "Media",
-    action: "Play audio notes",
-    description: "Short guidance clips that accompany tactile tasks.",
+  audio: {
+    title: "Audio Library",
+    sceneCode: "audio-gallery",
     color: 0xf2cc60,
+    description: "Curated audio material with tactile transport controls and spoken naming support.",
   },
-  {
-    slug: "recent_scenes",
-    label: "Recent Scenes",
-    type: "Workspace",
-    action: "Open recent scenes",
-    description: "Resume an object exploration or reading world.",
-    color: 0xc297ff,
+};
+
+const FILE_KIND_META = {
+  directory: { title: "Folder", color: 0x58a6ff, actionLabel: "Open folder" },
+  model: { title: "3D Model", color: 0x58a6ff, actionLabel: "Inspect item details" },
+  text: { title: "Text", color: 0x7ee787, actionLabel: "Inspect item details" },
+  audio: { title: "Audio", color: 0xf2cc60, actionLabel: "Inspect item details" },
+  unsupported: {
+    title: "Unsupported file",
+    color: 0xff7b72,
+    actionLabel: "Inspect unsupported file details",
   },
-  {
-    slug: "device_setup",
-    label: "Device Setup",
-    type: "Settings",
-    action: "Open device settings",
-    description: "Review available haptic backends and calibration.",
-    color: 0xffa657,
-  },
-  {
-    slug: "help_desk",
-    label: "Help Desk",
-    type: "Support",
-    action: "Open help desk",
-    description: "Access instructions, labels, and support notes.",
-    color: 0x39d2c0,
-  },
-];
+};
 
 const state = {
-  focusIndex: 0,
-  meshes: [],
-  layout: "grid",
+  workspaceCatalog: [],
+  activeWorkspace: null,
+  currentScene: null,
+  targets: new Map(),
+  focusOrder: [],
+  focusedTargetId: null,
+  hoveredTargetId: null,
+  fallbackFocusIndex: -1,
   pointerController: null,
-  hoveredIndex: null,
+  sceneApi: null,
+  loader: new OBJLoader(),
+  speechEnabled: true,
+  lastStatusKey: "",
+  lastAnnouncementKey: "",
+  brailleCache: new Map(),
+  textScene: null,
+  audioScene: null,
+  sceneBuildToken: 0,
 };
 
 function byId(id) {
   return document.getElementById(id);
 }
 
-function announce(text) {
-  if (byId("desktop-announcement").textContent === text) {
+function audioPlayer() {
+  return byId("desktop-audio-player");
+}
+
+function fetchJson(url, options = {}) {
+  return fetch(url, options).then(async (response) => {
+    if (!response.ok) {
+      const payload = await response.json().catch(() => ({}));
+      throw new Error(payload.detail || `Request failed: ${url}`);
+    }
+    return response.json();
+  });
+}
+
+function setRuntimePill(text, className = "status-pill-green") {
+  const pill = byId("desktop-runtime-pill");
+  pill.textContent = text;
+  pill.classList.remove(
+    "status-pill-cyan",
+    "status-pill-green",
+    "status-pill-purple",
+    "status-pill-danger",
+  );
+  pill.classList.add(className);
+}
+
+function setStatus(message, shortLabel = "Ready") {
+  byId("desktop-status-bar").textContent = message;
+  byId("desktop-page-status").textContent = shortLabel;
+}
+
+function speak(text) {
+  if (!state.speechEnabled || !("speechSynthesis" in window) || !text) {
     return;
   }
-  byId("desktop-announcement").textContent = text;
-  byId("desktop-status-bar").textContent = text;
-  byId("desktop-page-status").textContent = text;
+  try {
+    window.speechSynthesis.cancel();
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.rate = 1;
+    utterance.pitch = 1;
+    utterance.volume = 1;
+    window.speechSynthesis.speak(utterance);
+  } catch (error) {
+    console.warn("Speech synthesis is unavailable.", error);
+  }
 }
 
-function layoutPositions(layout) {
-  if (layout === "arc") {
-    return desktopItems.map((_, index) => {
-      const angle = -0.9 + index * 0.36;
-      return new THREE.Vector3(Math.sin(angle) * 1.55, 0.25, Math.cos(angle) * 1.1 - 0.2);
+function announce(message, key = message, options = {}) {
+  const { speakMessage = true } = options;
+  if (state.lastAnnouncementKey === key) {
+    return;
+  }
+  state.lastAnnouncementKey = key;
+  byId("desktop-announcement").textContent = message;
+  if (speakMessage) {
+    speak(message);
+  }
+}
+
+function publishStatus(message, shortLabel = "Ready", key = message, options = {}) {
+  if (state.lastStatusKey !== key) {
+    state.lastStatusKey = key;
+    setStatus(message, shortLabel);
+  }
+  announce(message, key, options);
+}
+
+function updateFocusedInspector(target) {
+  if (!target) {
+    byId("desktop-focus-label").textContent = "--";
+    byId("desktop-focus-type").textContent = "--";
+    byId("desktop-focus-action").textContent = "--";
+    return;
+  }
+  byId("desktop-focus-label").textContent = target.title;
+  byId("desktop-focus-type").textContent = target.type;
+  byId("desktop-focus-action").textContent = target.actionLabel;
+}
+
+function updateWorkspaceSummary() {
+  const workspace = state.activeWorkspace;
+  if (!workspace) {
+    byId("desktop-workspace-title").textContent = "No workspace";
+    byId("desktop-workspace-chip").textContent = "--";
+    return;
+  }
+  byId("desktop-workspace-title").textContent = workspace.title;
+  byId("desktop-workspace-chip").textContent = workspace.slug;
+}
+
+function updateSceneSummary(scene = null) {
+  const activeScene = scene ?? state.currentScene;
+  if (!activeScene) {
+    byId("desktop-scene-code").textContent = "--";
+    byId("desktop-scene-chip").textContent = "--";
+    byId("desktop-scene-label").textContent = "--";
+    byId("desktop-scene-context").textContent = "--";
+    byId("desktop-scene-path").textContent = "--";
+    byId("desktop-pagination").textContent = "--";
+    byId("desktop-scene-subtitle").textContent =
+      "Workspace-driven launcher, galleries, and opened-content scenes for blind-first exploration.";
+    return;
+  }
+  byId("desktop-scene-code").textContent = activeScene.code;
+  byId("desktop-scene-chip").textContent = activeScene.code;
+  byId("desktop-scene-label").textContent = activeScene.title;
+  byId("desktop-scene-context").textContent = activeScene.context || "--";
+  byId("desktop-scene-path").textContent = activeScene.path || "--";
+  byId("desktop-pagination").textContent = activeScene.pagination || "--";
+  byId("desktop-scene-subtitle").textContent = activeScene.subtitle;
+}
+
+function formatSeconds(value) {
+  if (!Number.isFinite(value)) {
+    return "--";
+  }
+  return `${value.toFixed(1)} s`;
+}
+
+function updateAudioSession(audioItem = state.audioScene?.item ?? null) {
+  const player = audioPlayer();
+  byId("desktop-audio-track").textContent = audioItem?.title ?? "--";
+  byId("desktop-audio-playback").textContent = player.paused ? "paused" : "playing";
+  byId("desktop-audio-position").textContent = formatSeconds(player.currentTime || 0);
+  byId("desktop-audio-duration").textContent = formatSeconds(player.duration);
+  byId("desktop-audio-state").textContent =
+    audioItem ? (player.paused ? "Paused" : "Playing") : "Off";
+}
+
+function resetAudioSession() {
+  const player = audioPlayer();
+  player.pause();
+  player.removeAttribute("src");
+  player.load();
+  state.audioScene = null;
+  byId("desktop-audio-track").textContent = "--";
+  byId("desktop-audio-playback").textContent = "idle";
+  byId("desktop-audio-position").textContent = "0.0 s";
+  byId("desktop-audio-duration").textContent = "--";
+  byId("desktop-audio-state").textContent = "Off";
+}
+
+function pauseSceneAudio() {
+  const player = audioPlayer();
+  player.pause();
+  updateAudioSession();
+}
+
+function bindAudioPlayer() {
+  const player = audioPlayer();
+  ["play", "pause", "timeupdate", "loadedmetadata", "ended"].forEach((eventName) => {
+    player.addEventListener(eventName, () => {
+      updateAudioSession();
+      if (eventName === "ended") {
+        publishStatus("Audio playback finished.", "Ready", "audio-ended", {
+          speakMessage: false,
+        });
+      }
     });
-  }
-  if (layout === "cluster") {
-    return [
-      new THREE.Vector3(-1.0, 0.25, -0.7),
-      new THREE.Vector3(0.0, 0.25, -0.75),
-      new THREE.Vector3(1.0, 0.25, -0.68),
-      new THREE.Vector3(-0.8, 0.25, 0.55),
-      new THREE.Vector3(0.2, 0.25, 0.48),
-      new THREE.Vector3(1.1, 0.25, 0.62),
-    ];
-  }
-  return [
-    new THREE.Vector3(-1.1, 0.25, -0.65),
-    new THREE.Vector3(0, 0.25, -0.65),
-    new THREE.Vector3(1.1, 0.25, -0.65),
-    new THREE.Vector3(-1.1, 0.25, 0.65),
-    new THREE.Vector3(0, 0.25, 0.65),
-    new THREE.Vector3(1.1, 0.25, 0.65),
-  ];
+  });
 }
 
-function buildPedestal(item) {
-  const group = new THREE.Group();
-
-  const pedestal = new THREE.Mesh(
-    new THREE.CylinderGeometry(0.32, 0.36, 0.08, 32),
-    new THREE.MeshStandardMaterial({ color: 0x0f1724, roughness: 0.88, metalness: 0.04 }),
-  );
-  pedestal.position.y = 0.04;
-  group.add(pedestal);
-
-  const halo = new THREE.Mesh(
-    new THREE.TorusGeometry(0.36, 0.024, 10, 40),
-    new THREE.MeshStandardMaterial({
-      color: item.color,
-      emissive: 0x08111a,
-      transparent: true,
-      opacity: 0.42,
-      roughness: 0.34,
-      metalness: 0.08,
-    }),
-  );
-  halo.rotation.x = Math.PI / 2;
-  halo.position.y = 0.095;
-  halo.userData.kind = "focus-halo";
-  halo.userData.baseOpacity = halo.material.opacity;
-  group.add(halo);
-
-  return group;
+function setCamera(position, target) {
+  state.sceneApi.camera.position.set(...position);
+  state.sceneApi.controls.target.set(...target);
+  state.sceneApi.controls.update();
 }
 
-function markAccent(mesh) {
-  mesh.userData.kind = "focus-target";
-  if (typeof mesh.material.roughness === "number") {
-    mesh.userData.baseRoughness = mesh.material.roughness;
+function normalizePage(page, pageCount) {
+  return Math.max(0, Math.min(pageCount - 1, page));
+}
+
+function slicePage(items, pageSize, page) {
+  const pageCount = Math.max(1, Math.ceil(items.length / pageSize));
+  const resolvedPage = normalizePage(page, pageCount);
+  const start = resolvedPage * pageSize;
+  return {
+    items: items.slice(start, start + pageSize),
+    pageCount,
+    page: resolvedPage,
+  };
+}
+
+function buildWorkspaceSelect() {
+  const select = byId("desktop-workspace-select");
+  select.innerHTML = "";
+  state.workspaceCatalog.forEach((workspace) => {
+    const option = document.createElement("option");
+    option.value = workspace.slug;
+    option.textContent = workspace.title;
+    select.appendChild(option);
+  });
+  const defaultWorkspace =
+    state.workspaceCatalog.find((workspace) => workspace.is_default) ??
+    state.workspaceCatalog[0] ??
+    null;
+  if (defaultWorkspace) {
+    select.value = defaultWorkspace.slug;
+  }
+}
+
+function currentSelectedWorkspaceSlug() {
+  return byId("desktop-workspace-select").value;
+}
+
+function registerInteractiveMesh(mesh, role = "base") {
+  mesh.userData.interactiveRole = role;
+  if (mesh.material?.emissive) {
+    mesh.userData.baseEmissive = mesh.material.emissive.getHex();
+  }
+  if (typeof mesh.material?.opacity === "number") {
+    mesh.userData.baseOpacity = mesh.material.opacity;
   }
   return mesh;
 }
 
-function buildLibraryShape(item) {
+function createBasePlatform(width, depth, accent = 0x39d2c0) {
   const group = new THREE.Group();
-  [-0.14, 0, 0.14].forEach((offset, index) => {
-    const slab = markAccent(
-      new THREE.Mesh(
-        new THREE.BoxGeometry(0.11, 0.38 + index * 0.04, 0.28),
-        new THREE.MeshStandardMaterial({
-          color: item.color,
-          roughness: 0.42,
-          metalness: 0.16,
-          emissive: 0x061018,
-        }),
-      ),
-    );
-    slab.position.set(offset, 0.24 + index * 0.02, 0);
-    slab.rotation.z = index === 1 ? 0 : (index === 0 ? -0.08 : 0.08);
-    group.add(slab);
-  });
+  const deck = new THREE.Mesh(
+    new THREE.BoxGeometry(width, 0.12, depth),
+    new THREE.MeshStandardMaterial({
+      color: 0x132136,
+      roughness: 0.92,
+      metalness: 0.05,
+    }),
+  );
+  deck.position.y = 0.06;
+  group.add(deck);
+
+  const topPlate = new THREE.Mesh(
+    new THREE.BoxGeometry(width - 0.18, 0.028, depth - 0.18),
+    new THREE.MeshStandardMaterial({
+      color: 0x0f1724,
+      roughness: 0.84,
+      metalness: 0.06,
+      emissive: 0x07111d,
+    }),
+  );
+  topPlate.position.y = 0.135;
+  group.add(topPlate);
+
+  const frontLip = new THREE.Mesh(
+    new THREE.BoxGeometry(width - 0.26, 0.06, 0.08),
+    new THREE.MeshStandardMaterial({
+      color: 0x0f1724,
+      roughness: 0.88,
+      metalness: 0.04,
+    }),
+  );
+  frontLip.position.set(0, 0.105, depth / 2 - 0.12);
+  group.add(frontLip);
+
+  const originMarker = new THREE.Mesh(
+    new THREE.ConeGeometry(0.08, 0.14, 3),
+    new THREE.MeshStandardMaterial({
+      color: accent,
+      roughness: 0.32,
+      metalness: 0.05,
+      emissive: new THREE.Color(accent).multiplyScalar(0.18),
+    }),
+  );
+  originMarker.rotation.y = Math.PI;
+  originMarker.position.set(-width / 2 + 0.24, 0.17, depth / 2 - 0.24);
+  group.add(originMarker);
   return group;
 }
 
-function buildBrailleShelfShape(item) {
+function addSceneTitle(world, title, subtitle) {
+  const titleSprite = createLabelSprite(title, {
+    background: "rgba(13, 17, 23, 0.88)",
+    color: "#e6edf3",
+    fontSize: 24,
+  });
+  titleSprite.position.set(0, 1.18, -1.5);
+  world.add(titleSprite);
+
+  const subtitleSprite = createLabelSprite(subtitle, {
+    background: "rgba(13, 17, 23, 0.76)",
+    color: "#8b949e",
+    fontSize: 15,
+  });
+  subtitleSprite.position.set(0, 0.92, -1.5);
+  world.add(subtitleSprite);
+}
+
+function addFloatingLabel(group, text, y = 0.72, color = "#8b949e") {
+  const sprite = createLabelSprite(text, {
+    background: "rgba(13, 17, 23, 0.80)",
+    color,
+    fontSize: 15,
+  });
+  sprite.position.set(0, y, 0);
+  group.add(sprite);
+}
+
+function beginSceneBuild(title) {
+  const token = ++state.sceneBuildToken;
+  setRuntimePill(`Loading ${title}`, "status-pill-purple");
+  setStatus(`Loading ${title}.`, "Loading");
+  return token;
+}
+
+function assertSceneToken(token) {
+  if (token !== state.sceneBuildToken) {
+    throw new Error("Stale scene build interrupted.");
+  }
+}
+
+function finishSceneBuild(scene) {
+  state.currentScene = scene;
+  updateSceneSummary(scene);
+  setRuntimePill("Desktop active", "status-pill-green");
+}
+
+function buildControlButton(kind, accent, disabled = false) {
   const group = new THREE.Group();
-  const slab = markAccent(
+  const accentColor = disabled ? 0x4b5563 : accent;
+
+  const base = registerInteractiveMesh(
     new THREE.Mesh(
-      new THREE.BoxGeometry(0.46, 0.14, 0.34),
+      new THREE.BoxGeometry(0.44, 0.08, 0.32),
       new THREE.MeshStandardMaterial({
-        color: item.color,
-        roughness: 0.5,
+        color: disabled ? 0x1b222d : 0x16213a,
+        roughness: 0.78,
         metalness: 0.08,
         emissive: 0x08111a,
       }),
     ),
+    "base",
+  );
+  base.position.y = 0.04;
+  group.add(base);
+
+  const material = new THREE.MeshStandardMaterial({
+    color: accentColor,
+    roughness: 0.34,
+    metalness: 0.08,
+    emissive: new THREE.Color(accentColor).multiplyScalar(0.12),
+  });
+
+  if (kind === "home") {
+    const roof = registerInteractiveMesh(new THREE.Mesh(new THREE.ConeGeometry(0.11, 0.14, 4), material), "accent");
+    roof.position.set(0, 0.16, -0.02);
+    roof.rotation.y = Math.PI / 4;
+    group.add(roof);
+    const body = registerInteractiveMesh(
+      new THREE.Mesh(new THREE.BoxGeometry(0.16, 0.14, 0.14), material.clone()),
+      "accent",
+    );
+    body.position.set(0, 0.12, 0.04);
+    group.add(body);
+  } else if (kind === "back") {
+    [-0.07, 0.03].forEach((offset) => {
+      const arrow = registerInteractiveMesh(
+        new THREE.Mesh(new THREE.ConeGeometry(0.05, 0.12, 3), material.clone()),
+        "accent",
+      );
+      arrow.rotation.z = Math.PI / 2;
+      arrow.position.set(offset, 0.13, 0);
+      group.add(arrow);
+    });
+    const bar = registerInteractiveMesh(
+      new THREE.Mesh(new THREE.BoxGeometry(0.12, 0.04, 0.06), material.clone()),
+      "accent",
+    );
+    bar.position.set(0.1, 0.13, 0);
+    group.add(bar);
+  } else if (kind === "up") {
+    const shaft = registerInteractiveMesh(
+      new THREE.Mesh(new THREE.CylinderGeometry(0.028, 0.028, 0.16, 18), material),
+      "accent",
+    );
+    shaft.position.y = 0.13;
+    group.add(shaft);
+    const arrow = registerInteractiveMesh(
+      new THREE.Mesh(new THREE.ConeGeometry(0.06, 0.12, 3), material.clone()),
+      "accent",
+    );
+    arrow.position.y = 0.24;
+    group.add(arrow);
+  } else if (kind === "open") {
+    const frame = registerInteractiveMesh(
+      new THREE.Mesh(new THREE.BoxGeometry(0.2, 0.16, 0.04), material),
+      "accent",
+    );
+    frame.position.set(-0.03, 0.14, 0);
+    group.add(frame);
+    const arrow = registerInteractiveMesh(
+      new THREE.Mesh(new THREE.ConeGeometry(0.05, 0.12, 3), material.clone()),
+      "accent",
+    );
+    arrow.rotation.z = -Math.PI / 2;
+    arrow.position.set(0.12, 0.14, 0);
+    group.add(arrow);
+  } else if (kind === "previous") {
+    [-0.1, 0, 0.1].forEach((offset) => {
+      const ridge = registerInteractiveMesh(
+        new THREE.Mesh(new THREE.CylinderGeometry(0.022, 0.022, 0.2, 18), material.clone()),
+        "accent",
+      );
+      ridge.rotation.z = Math.PI / 2;
+      ridge.position.set(offset, 0.12, 0);
+      group.add(ridge);
+    });
+  } else if (kind === "next") {
+    const dome = registerInteractiveMesh(
+      new THREE.Mesh(new THREE.SphereGeometry(0.08, 20, 16), material),
+      "accent",
+    );
+    dome.scale.set(1, 0.72, 1);
+    dome.position.set(0, 0.11, 0);
+    group.add(dome);
+    const arrow = registerInteractiveMesh(
+      new THREE.Mesh(new THREE.ConeGeometry(0.05, 0.12, 3), material.clone()),
+      "accent",
+    );
+    arrow.rotation.z = -Math.PI / 2;
+    arrow.position.set(0.14, 0.11, 0);
+    group.add(arrow);
+  } else if (kind === "playpause") {
+    const left = registerInteractiveMesh(
+      new THREE.Mesh(new THREE.BoxGeometry(0.04, 0.15, 0.06), material),
+      "accent",
+    );
+    left.position.set(-0.04, 0.12, 0);
+    group.add(left);
+    const right = registerInteractiveMesh(
+      new THREE.Mesh(new THREE.BoxGeometry(0.04, 0.15, 0.06), material.clone()),
+      "accent",
+    );
+    right.position.set(0.04, 0.12, 0);
+    group.add(right);
+  } else if (kind === "seek-back" || kind === "seek-forward") {
+    [-0.05, 0.05].forEach((offset) => {
+      const arrow = registerInteractiveMesh(
+        new THREE.Mesh(new THREE.ConeGeometry(0.05, 0.12, 3), material.clone()),
+        "accent",
+      );
+      arrow.rotation.z = kind === "seek-back" ? Math.PI / 2 : -Math.PI / 2;
+      arrow.position.set(offset, 0.12, 0);
+      group.add(arrow);
+    });
+  }
+
+  return group;
+}
+
+function buildFolderSymbol(color) {
+  const group = new THREE.Group();
+  const body = registerInteractiveMesh(
+    new THREE.Mesh(
+      new THREE.BoxGeometry(0.42, 0.2, 0.28),
+      new THREE.MeshStandardMaterial({
+        color,
+        roughness: 0.46,
+        metalness: 0.08,
+        emissive: new THREE.Color(color).multiplyScalar(0.08),
+      }),
+    ),
+    "accent",
+  );
+  body.position.y = 0.16;
+  group.add(body);
+  const tab = registerInteractiveMesh(
+    new THREE.Mesh(
+      new THREE.BoxGeometry(0.18, 0.08, 0.22),
+      new THREE.MeshStandardMaterial({
+        color,
+        roughness: 0.42,
+        metalness: 0.06,
+        emissive: new THREE.Color(color).multiplyScalar(0.1),
+      }),
+    ),
+    "accent",
+  );
+  tab.position.set(-0.08, 0.28, -0.03);
+  group.add(tab);
+  return group;
+}
+
+function buildTextSymbol(color) {
+  const group = new THREE.Group();
+  const slab = registerInteractiveMesh(
+    new THREE.Mesh(
+      new THREE.BoxGeometry(0.4, 0.14, 0.3),
+      new THREE.MeshStandardMaterial({
+        color,
+        roughness: 0.52,
+        metalness: 0.06,
+        emissive: new THREE.Color(color).multiplyScalar(0.06),
+      }),
+    ),
+    "accent",
   );
   slab.position.y = 0.14;
   group.add(slab);
-
-  const offsets = [
-    [-0.09, 0.05],
-    [0.01, 0.05],
-    [-0.09, -0.02],
-    [0.01, -0.02],
-    [-0.09, -0.09],
-    [0.01, -0.09],
-  ];
-  offsets.forEach(([x, z], index) => {
-    if (index === 1 || index === 2 || index === 4 || index === 5) {
-      const dot = markAccent(
+  [
+    [-0.08, 0.06],
+    [0, 0.06],
+    [-0.08, -0.02],
+    [0, -0.02],
+    [-0.08, -0.1],
+    [0, -0.1],
+  ].forEach(([x, z], index) => {
+    if ([0, 1, 3, 5].includes(index)) {
+      const dot = registerInteractiveMesh(
         new THREE.Mesh(
-          new THREE.SphereGeometry(0.03, 16, 12, 0, Math.PI * 2, 0, Math.PI / 2),
+          new THREE.SphereGeometry(0.026, 18, 14, 0, Math.PI * 2, 0, Math.PI / 2),
           new THREE.MeshStandardMaterial({
             color: 0xe6edf3,
             roughness: 0.22,
@@ -199,302 +597,1491 @@ function buildBrailleShelfShape(item) {
             emissive: 0x14263d,
           }),
         ),
+        "accent",
       );
       dot.rotation.x = Math.PI;
-      dot.position.set(x, 0.225, z);
+      dot.position.set(x, 0.22, z);
       group.add(dot);
     }
   });
   return group;
 }
 
-function buildAudioShape(item) {
+function buildAudioSymbol(color) {
   const group = new THREE.Group();
-  const speaker = markAccent(
+  const speaker = registerInteractiveMesh(
     new THREE.Mesh(
-      new THREE.CylinderGeometry(0.18, 0.22, 0.42, 32),
+      new THREE.CylinderGeometry(0.16, 0.2, 0.36, 24),
       new THREE.MeshStandardMaterial({
-        color: item.color,
-        roughness: 0.4,
-        metalness: 0.18,
-        emissive: 0x08111a,
-      }),
-    ),
-  );
-  speaker.position.y = 0.25;
-  group.add(speaker);
-
-  [0.16, 0.25].forEach((radius, index) => {
-    const ring = markAccent(
-      new THREE.Mesh(
-        new THREE.TorusGeometry(radius, 0.016, 10, 32),
-        new THREE.MeshStandardMaterial({
-          color: item.color,
-          roughness: 0.26,
-          metalness: 0.08,
-          emissive: 0x302300,
-          transparent: true,
-          opacity: 0.85 - index * 0.18,
-        }),
-      ),
-    );
-    ring.rotation.y = Math.PI / 2;
-    ring.position.set(0.16 + index * 0.12, 0.28, 0);
-    group.add(ring);
-  });
-  return group;
-}
-
-function buildRecentScenesShape(item) {
-  const group = new THREE.Group();
-  [0, 1, 2].forEach((index) => {
-    const frame = markAccent(
-      new THREE.Mesh(
-        new THREE.BoxGeometry(0.34, 0.06, 0.42),
-        new THREE.MeshStandardMaterial({
-          color: item.color,
-          roughness: 0.46,
-          metalness: 0.1,
-          emissive: 0x08111a,
-        }),
-      ),
-    );
-    frame.position.set(-0.08 + index * 0.08, 0.14 + index * 0.1, 0);
-    frame.rotation.x = -0.3;
-    frame.rotation.y = -0.12 + index * 0.08;
-    group.add(frame);
-  });
-  return group;
-}
-
-function buildDeviceSetupShape(item) {
-  const group = new THREE.Group();
-  const hub = markAccent(
-    new THREE.Mesh(
-      new THREE.CylinderGeometry(0.16, 0.16, 0.18, 28),
-      new THREE.MeshStandardMaterial({
-        color: item.color,
-        roughness: 0.34,
-        metalness: 0.28,
-        emissive: 0x14100a,
-      }),
-    ),
-  );
-  hub.position.y = 0.22;
-  group.add(hub);
-
-  for (let index = 0; index < 8; index += 1) {
-    const tooth = markAccent(
-      new THREE.Mesh(
-        new THREE.BoxGeometry(0.08, 0.12, 0.08),
-        new THREE.MeshStandardMaterial({
-          color: item.color,
-          roughness: 0.36,
-          metalness: 0.24,
-          emissive: 0x14100a,
-        }),
-      ),
-    );
-    const angle = (index / 8) * Math.PI * 2;
-    tooth.position.set(Math.cos(angle) * 0.24, 0.22, Math.sin(angle) * 0.24);
-    tooth.rotation.y = angle;
-    group.add(tooth);
-  }
-  return group;
-}
-
-function buildHelpDeskShape(item) {
-  const group = new THREE.Group();
-  const pillar = markAccent(
-    new THREE.Mesh(
-      new THREE.CylinderGeometry(0.12, 0.16, 0.52, 24),
-      new THREE.MeshStandardMaterial({
-        color: item.color,
+        color,
         roughness: 0.38,
-        metalness: 0.1,
-        emissive: 0x08111a,
+        metalness: 0.18,
+        emissive: new THREE.Color(color).multiplyScalar(0.08),
       }),
     ),
+    "accent",
   );
-  pillar.position.y = 0.3;
-  group.add(pillar);
-
-  const cap = markAccent(
-    new THREE.Mesh(
-      new THREE.SphereGeometry(0.12, 18, 14),
-      new THREE.MeshStandardMaterial({
-        color: 0xe6edf3,
-        roughness: 0.22,
-        metalness: 0.14,
-        emissive: 0x10263a,
-      }),
-    ),
-  );
-  cap.position.y = 0.6;
-  cap.scale.set(1, 0.7, 1);
-  group.add(cap);
-  return group;
-}
-
-function buildDesktopObject(item, position) {
-  const group = new THREE.Group();
-  group.position.copy(position);
-  group.userData.accentColor = item.color;
-  group.add(buildPedestal(item));
-
-  const shapeBuilders = {
-    models_library: buildLibraryShape,
-    braille_shelf: buildBrailleShelfShape,
-    audio_notes: buildAudioShape,
-    recent_scenes: buildRecentScenesShape,
-    device_setup: buildDeviceSetupShape,
-    help_desk: buildHelpDeskShape,
-  };
-  group.add(shapeBuilders[item.slug](item));
-
-  return group;
-}
-
-function renderLayout(sceneApi) {
-  sceneApi.clearWorld();
-  state.meshes = [];
-
-  const desk = new THREE.Mesh(
-    new THREE.BoxGeometry(4.4, 0.1, 3.2),
-    new THREE.MeshStandardMaterial({ color: 0x111827, roughness: 0.94, metalness: 0.06 }),
-  );
-  desk.position.y = 0.05;
-  sceneApi.world.add(desk);
-
-  const frontRidge = new THREE.Mesh(
-    new THREE.BoxGeometry(4.0, 0.06, 0.08),
-    new THREE.MeshStandardMaterial({ color: 0x0f1724, roughness: 0.88, metalness: 0.04 }),
-  );
-  frontRidge.position.set(0, 0.11, 1.44);
-  sceneApi.world.add(frontRidge);
-
-  const originMarker = new THREE.Mesh(
-    new THREE.ConeGeometry(0.09, 0.16, 3),
-    new THREE.MeshStandardMaterial({
-      color: 0x39d2c0,
-      roughness: 0.32,
-      metalness: 0.04,
-      emissive: 0x0e2b29,
-    }),
-  );
-  originMarker.rotation.y = Math.PI;
-  originMarker.position.set(-1.82, 0.17, 1.22);
-  sceneApi.world.add(originMarker);
-
-  const positions = layoutPositions(state.layout);
-  desktopItems.forEach((item, index) => {
-    const group = buildDesktopObject(item, positions[index]);
-    group.userData.itemIndex = index;
-    state.meshes.push(group);
-    sceneApi.world.add(group);
+  speaker.position.y = 0.22;
+  group.add(speaker);
+  [0.14, 0.24].forEach((radius, index) => {
+    const wave = registerInteractiveMesh(
+      new THREE.Mesh(
+        new THREE.TorusGeometry(radius, 0.014, 10, 28),
+        new THREE.MeshStandardMaterial({
+          color,
+          roughness: 0.28,
+          metalness: 0.04,
+          emissive: new THREE.Color(color).multiplyScalar(0.12),
+          transparent: true,
+          opacity: 0.88 - index * 0.24,
+        }),
+      ),
+      "halo",
+    );
+    wave.rotation.y = Math.PI / 2;
+    wave.position.set(0.14 + index * 0.1, 0.24, 0);
+    group.add(wave);
   });
-
-  sceneApi.setBoundarySize(new THREE.Vector3(5.0, 1.4, 3.8));
-  state.pointerController?.setBounds(
-    new THREE.Vector3(-2.1, 0.18, -1.55),
-    new THREE.Vector3(2.1, 0.95, 1.55),
-  );
-  updateFocus(sceneApi, "layout");
+  return group;
 }
 
-function updateFocus(sceneApi, source = "focus") {
-  const item = desktopItems[state.focusIndex];
-  state.meshes.forEach((group, index) => {
-    group.traverse((node) => {
+function buildModelSymbol(color) {
+  const group = new THREE.Group();
+  const base = registerInteractiveMesh(
+    new THREE.Mesh(
+      new THREE.CylinderGeometry(0.24, 0.28, 0.08, 28),
+      new THREE.MeshStandardMaterial({
+        color: 0x101722,
+        roughness: 0.86,
+        metalness: 0.06,
+        emissive: 0x09111c,
+      }),
+    ),
+    "base",
+  );
+  base.position.y = 0.04;
+  group.add(base);
+  const peak = registerInteractiveMesh(
+    new THREE.Mesh(
+      new THREE.IcosahedronGeometry(0.18, 0),
+      new THREE.MeshStandardMaterial({
+        color,
+        roughness: 0.42,
+        metalness: 0.08,
+        emissive: new THREE.Color(color).multiplyScalar(0.1),
+      }),
+    ),
+    "accent",
+  );
+  peak.position.y = 0.25;
+  peak.scale.set(1.1, 0.88, 1);
+  group.add(peak);
+  return group;
+}
+
+function buildUnsupportedSymbol(color) {
+  const group = new THREE.Group();
+  const body = registerInteractiveMesh(
+    new THREE.Mesh(
+      new THREE.OctahedronGeometry(0.2, 0),
+      new THREE.MeshStandardMaterial({
+        color,
+        roughness: 0.62,
+        metalness: 0.08,
+        emissive: new THREE.Color(color).multiplyScalar(0.1),
+      }),
+    ),
+    "accent",
+  );
+  body.position.y = 0.18;
+  group.add(body);
+  const band = registerInteractiveMesh(
+    new THREE.Mesh(
+      new THREE.TorusGeometry(0.22, 0.014, 10, 32),
+      new THREE.MeshStandardMaterial({
+        color: 0xffb4ab,
+        roughness: 0.28,
+        metalness: 0.06,
+        emissive: 0x412320,
+      }),
+    ),
+    "accent",
+  );
+  band.rotation.x = Math.PI / 2;
+  band.position.y = 0.18;
+  group.add(band);
+  return group;
+}
+
+function buildTileBase(color) {
+  const group = new THREE.Group();
+  const pedestal = registerInteractiveMesh(
+    new THREE.Mesh(
+      new THREE.CylinderGeometry(0.34, 0.38, 0.08, 32),
+      new THREE.MeshStandardMaterial({
+        color: 0x0f1724,
+        roughness: 0.88,
+        metalness: 0.04,
+        emissive: 0x09111c,
+      }),
+    ),
+    "base",
+  );
+  pedestal.position.y = 0.04;
+  group.add(pedestal);
+  const halo = registerInteractiveMesh(
+    new THREE.Mesh(
+      new THREE.TorusGeometry(0.38, 0.022, 10, 40),
+      new THREE.MeshStandardMaterial({
+        color,
+        roughness: 0.32,
+        metalness: 0.04,
+        emissive: new THREE.Color(color).multiplyScalar(0.12),
+        transparent: true,
+        opacity: 0.42,
+      }),
+    ),
+    "halo",
+  );
+  halo.rotation.x = Math.PI / 2;
+  halo.position.y = 0.088;
+  group.add(halo);
+  return group;
+}
+
+function buildInteractiveTile(title, symbolBuilder, color) {
+  const group = new THREE.Group();
+  group.add(buildTileBase(color));
+  group.add(symbolBuilder(color));
+  addFloatingLabel(group, title, 0.78, "#8b949e");
+  return group;
+}
+
+function createTarget({
+  id,
+  title,
+  type,
+  actionLabel,
+  group,
+  position,
+  radius,
+  onActivate,
+  color = 0x39d2c0,
+  disabled = false,
+}) {
+  group.position.copy(position);
+  group.userData.basePosition = position.clone();
+  state.targets.set(id, {
+    id,
+    title,
+    type,
+    actionLabel,
+    group,
+    position,
+    radius,
+    onActivate,
+    highlightHex: color,
+    disabled,
+  });
+  state.focusOrder.push(id);
+  state.sceneApi.world.add(group);
+}
+
+function clearTargets() {
+  state.targets.clear();
+  state.focusOrder = [];
+  state.focusedTargetId = null;
+  state.hoveredTargetId = null;
+  state.fallbackFocusIndex = -1;
+  updateFocusedInspector(null);
+}
+
+function refreshTargetVisuals() {
+  state.targets.forEach((target) => {
+    const isFocused = target.id === state.focusedTargetId || target.id === state.hoveredTargetId;
+    const highlight = new THREE.Color(target.highlightHex);
+    const restingY = target.group.userData.basePosition?.y ?? target.group.position.y;
+    target.group.position.y = restingY + (isFocused ? 0.035 : 0);
+    target.group.scale.setScalar(target.disabled ? 0.94 : isFocused ? 1.06 : 1);
+    target.group.traverse((node) => {
       if (!node.isMesh) {
         return;
       }
-
-      if (node.userData.kind === "focus-target") {
-        node.material.emissive.setHex(index === state.focusIndex ? 0x1f6feb : 0x08111a);
-        if (typeof node.userData.baseRoughness === "number") {
-          node.material.roughness = index === state.focusIndex
-            ? Math.max(0.2, node.userData.baseRoughness - 0.08)
-            : node.userData.baseRoughness;
-        }
+      const role = node.userData.interactiveRole;
+      const baseEmissive = node.userData.baseEmissive ?? 0x000000;
+      const baseOpacity = node.userData.baseOpacity ?? 1;
+      if (node.material?.emissive) {
+        node.material.emissive.setHex(
+          isFocused
+            ? highlight.clone().multiplyScalar(role === "accent" ? 0.18 : 0.1).getHex()
+            : baseEmissive,
+        );
       }
-
-      if (node.userData.kind === "focus-halo") {
-        node.material.opacity = index === state.focusIndex ? 0.78 : node.userData.baseOpacity;
-        node.material.emissive.setHex(index === state.focusIndex ? 0x1f6feb : 0x08111a);
+      if (role === "halo" && typeof node.material?.opacity === "number") {
+        node.material.opacity = isFocused ? Math.min(0.8, baseOpacity + 0.26) : baseOpacity;
       }
     });
   });
+}
 
-  const focusPosition = state.meshes[state.focusIndex].position.clone();
-  if (source !== "pointer") {
-    state.pointerController?.setPosition(focusPosition.clone().add(new THREE.Vector3(0, 0.62, 0.42)));
+function focusTarget(targetId, options = {}) {
+  const { source = "fallback", announceFocus = true, movePointer = true } = options;
+  const target = state.targets.get(targetId);
+  if (!target) {
+    return;
   }
-  sceneApi.setPointerState(source === "pointer" ? "focus" : "idle");
-
-  byId("desktop-focus-count").textContent = `${state.focusIndex + 1} / ${desktopItems.length}`;
-  byId("desktop-focus-label").textContent = item.label;
-  byId("desktop-focus-type").textContent = item.type;
-  byId("desktop-focus-action").textContent = item.action;
-  announce(
-    source === "pointer"
-      ? `Pointer over ${item.label}. ${item.description}`
-      : `${item.label}. ${item.description}`,
-  );
+  state.focusedTargetId = targetId;
+  state.fallbackFocusIndex = state.focusOrder.indexOf(targetId);
+  updateFocusedInspector(target);
+  refreshTargetVisuals();
+  if (movePointer && source !== "pointer") {
+    state.pointerController?.setPosition(
+      target.position.clone().setY(Math.max(target.position.y + 0.22, 0.24)),
+    );
+  }
+  state.sceneApi.setPointerState(source === "pointer" ? "focus" : "idle");
+  if (announceFocus) {
+    publishStatus(`${target.title}. ${target.actionLabel}.`, "Ready", `focus-${targetId}`);
+  }
 }
 
-function moveFocus(sceneApi, step) {
-  state.focusIndex = (state.focusIndex + step + desktopItems.length) % desktopItems.length;
-  updateFocus(sceneApi);
+function moveFallbackFocus(step) {
+  if (state.focusOrder.length === 0) {
+    return;
+  }
+  const nextIndex =
+    ((state.fallbackFocusIndex < 0 ? 0 : state.fallbackFocusIndex) + step + state.focusOrder.length) %
+    state.focusOrder.length;
+  focusTarget(state.focusOrder[nextIndex], { source: "fallback" });
 }
 
-function activateFocusedItem(sceneApi, source = "pointer") {
-  const item = desktopItems[state.focusIndex];
-  sceneApi.setPointerState("active");
-  window.setTimeout(() => {
-    sceneApi.setPointerState(source === "pointer" ? "focus" : "idle");
-  }, 180);
-  announce(
-    source === "pointer"
-      ? `${item.label}. ${item.action}. Pointer activation confirmed.`
-      : `${item.label}. ${item.action}.`,
-  );
-}
-
-function updatePointerFocus(sceneApi, position) {
-  let nearestIndex = null;
+function updatePointerHover(position) {
+  let nearestTarget = null;
   let nearestDistance = Number.POSITIVE_INFINITY;
-
-  state.meshes.forEach((group, index) => {
-    const target = group.position.clone().add(new THREE.Vector3(0, 0.32, 0));
-    const distance = target.distanceTo(position);
-    if (distance <= 0.68 && distance < nearestDistance) {
+  state.targets.forEach((target) => {
+    const distance = target.position.distanceTo(position);
+    if (distance <= target.radius && distance < nearestDistance) {
+      nearestTarget = target;
       nearestDistance = distance;
-      nearestIndex = index;
+    }
+  });
+  if (!nearestTarget) {
+    if (state.hoveredTargetId !== null) {
+      state.hoveredTargetId = null;
+      refreshTargetVisuals();
+    }
+    state.sceneApi.setPointerState("idle");
+    publishStatus(
+      state.currentScene?.idleMessage ?? "Pointer moving across the current tactile scene.",
+      "Ready",
+      state.currentScene?.idleMessage ?? "pointer-idle",
+      { speakMessage: false },
+    );
+    return;
+  }
+  if (state.hoveredTargetId !== nearestTarget.id || state.focusedTargetId !== nearestTarget.id) {
+    state.hoveredTargetId = nearestTarget.id;
+    focusTarget(nearestTarget.id, { source: "pointer", movePointer: false });
+  }
+}
+
+async function activateFocusedTarget(source = "pointer") {
+  const targetId = state.hoveredTargetId ?? state.focusedTargetId;
+  const target = state.targets.get(targetId);
+  if (!target) {
+    publishStatus("No tactile control is currently under the pointer.", "Ready", "no-target");
+    return;
+  }
+  if (target.disabled) {
+    publishStatus(`${target.title} is unavailable in this state.`, "Ready", `disabled-${target.id}`);
+    return;
+  }
+  state.sceneApi.setPointerState("active");
+  publishStatus(`${target.title}. ${target.actionLabel}.`, "Active", `activate-${target.id}`);
+  try {
+    await target.onActivate?.(source);
+  } finally {
+    window.setTimeout(() => {
+      state.sceneApi.setPointerState(source === "pointer" ? "focus" : "idle");
+    }, 160);
+  }
+}
+
+function prepareScene(
+  width,
+  depth,
+  title,
+  subtitle,
+  cameraPosition = [4.9, 3.2, 5.1],
+  target = [0, 0.28, 0.08],
+  keepAudioSession = false,
+) {
+  if (!keepAudioSession) {
+    resetAudioSession();
+  }
+  clearTargets();
+  state.sceneApi.clearWorld();
+  state.sceneApi.setBoundarySize(new THREE.Vector3(width + 0.6, 1.6, depth + 0.6));
+  state.sceneApi.setGridVisible(true);
+  state.sceneApi.setBoundaryVisible(true);
+  setCamera(cameraPosition, target);
+  state.sceneApi.world.add(createBasePlatform(width, depth));
+  addSceneTitle(state.sceneApi.world, title, subtitle);
+}
+
+async function fetchBraillePreview(text, columns) {
+  const normalizedText = (text || "").trim() || "FeelIT";
+  const key = `${columns}:${normalizedText}`;
+  if (state.brailleCache.has(key)) {
+    return state.brailleCache.get(key);
+  }
+  const payload = await fetchJson(braillePreviewUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ text: normalizedText, columns }),
+  });
+  state.brailleCache.set(key, payload);
+  return payload;
+}
+
+function createBrailleCellGroup(cell, columns, rowOffset = 0, options = {}) {
+  const spacingX = options.spacingX ?? 0.28;
+  const spacingZ = options.spacingZ ?? 0.38;
+  const originX = -((columns - 1) * spacingX) / 2;
+  const localRow = cell.row - rowOffset;
+  const x = originX + cell.column * spacingX;
+  const z = localRow * spacingZ;
+  const group = new THREE.Group();
+  group.position.set(x, 0, z);
+
+  const cellBase = new THREE.Mesh(
+    new THREE.BoxGeometry(0.18, 0.02, 0.24),
+    new THREE.MeshStandardMaterial({
+      color: options.baseColor ?? 0x111827,
+      roughness: 0.86,
+      metalness: 0.04,
+      emissive: 0x08111a,
+    }),
+  );
+  cellBase.position.y = 0.01;
+  group.add(cellBase);
+
+  [
+    [-0.04, 0.05],
+    [0.04, 0.05],
+    [-0.04, 0],
+    [0.04, 0],
+    [-0.04, -0.05],
+    [0.04, -0.05],
+  ].forEach(([dotX, dotZ], index) => {
+    if (cell.dots[index]) {
+      const dot = new THREE.Mesh(
+        new THREE.SphereGeometry(0.024, 16, 12, 0, Math.PI * 2, 0, Math.PI / 2),
+        new THREE.MeshStandardMaterial({
+          color: options.dotColor ?? 0xf2cc60,
+          roughness: 0.35,
+          metalness: 0.04,
+          emissive: 0x422800,
+        }),
+      );
+      dot.rotation.x = Math.PI;
+      dot.position.set(dotX, 0.038, dotZ);
+      group.add(dot);
     }
   });
 
-  if (nearestIndex === null) {
-    state.hoveredIndex = null;
-    sceneApi.setPointerState("idle");
-    announce("Pointer moving across the desktop workspace.");
-    return;
-  }
-
-  if (state.hoveredIndex !== nearestIndex || state.focusIndex !== nearestIndex) {
-    state.hoveredIndex = nearestIndex;
-    state.focusIndex = nearestIndex;
-    updateFocus(sceneApi, "pointer");
-  }
+  return group;
 }
 
-function activatePointerTarget(sceneApi) {
-  if (state.hoveredIndex === null) {
-    announce("No desktop object is currently under the pointer.");
+function buildBraillePlaque(cells, columns, options = {}) {
+  const rowCount = cells.length ? Math.max(...cells.map((cell) => cell.row)) + 1 : 1;
+  const maxRows = options.maxRows ?? rowCount;
+  const visibleCells = cells.filter((cell) => cell.row < maxRows);
+  const width = Math.max(1.4, columns * (options.spacingX ?? 0.28) + 0.6);
+  const depth = Math.max(0.9, maxRows * (options.spacingZ ?? 0.38) + 0.5);
+  const group = new THREE.Group();
+
+  const base = new THREE.Mesh(
+    new THREE.BoxGeometry(width, 0.08, depth),
+    new THREE.MeshStandardMaterial({
+      color: options.surfaceColor ?? 0x16213a,
+      roughness: 0.9,
+      metalness: 0.05,
+      emissive: 0x08111a,
+    }),
+  );
+  base.position.y = 0.04;
+  group.add(base);
+
+  const orientation = new THREE.Mesh(
+    new THREE.ConeGeometry(0.07, 0.12, 3),
+    new THREE.MeshStandardMaterial({
+      color: options.markerColor ?? 0x39d2c0,
+      roughness: 0.32,
+      metalness: 0.04,
+      emissive: 0x0f2c2a,
+    }),
+  );
+  orientation.rotation.y = Math.PI;
+  orientation.position.set(-width / 2 + 0.14, 0.13, depth / 2 - 0.16);
+  group.add(orientation);
+
+  visibleCells.forEach((cell) => {
+    const cellGroup = createBrailleCellGroup(cell, columns, 0, options);
+    cellGroup.position.z -= ((maxRows - 1) * (options.spacingZ ?? 0.38)) / 2;
+    group.add(cellGroup);
+  });
+
+  return group;
+}
+
+function galleryTilePositions(count) {
+  return [
+    new THREE.Vector3(-1.55, 0.12, -0.72),
+    new THREE.Vector3(0, 0.12, -0.72),
+    new THREE.Vector3(1.55, 0.12, -0.72),
+    new THREE.Vector3(-1.55, 0.12, 0.82),
+    new THREE.Vector3(0, 0.12, 0.82),
+    new THREE.Vector3(1.55, 0.12, 0.82),
+  ].slice(0, count);
+}
+
+function resolveItemKind(item) {
+  return item.kind ?? item.category?.slice(0, -1) ?? "unsupported";
+}
+
+function kindMeta(kind) {
+  return FILE_KIND_META[kind] ?? FILE_KIND_META.unsupported;
+}
+
+function itemRawFileUrl(item) {
+  if (item.source?.kind === "demo_model" || item.source?.kind === "library_audio") {
+    return item.source.file_url;
+  }
+  if (item.source?.kind === "workspace_file") {
+    return workspaceRawUrl(state.activeWorkspace.slug, item.source.relative_path);
+  }
+  return item.source?.file_url ?? "";
+}
+
+function itemTextEndpoint(item, offset, maxChars) {
+  if (item.source?.kind === "library_document") {
+    return `${item.source.text_endpoint}?offset=${offset}&max_chars=${maxChars}`;
+  }
+  if (item.source?.kind === "workspace_file") {
+    return workspaceTextUrl(state.activeWorkspace.slug, item.source.relative_path, offset, maxChars);
+  }
+  throw new Error("This item does not expose a readable text payload.");
+}
+
+function detailOriginLabel(origin) {
+  if (!origin) {
+    return "Launcher";
+  }
+  if (origin.type === "gallery") {
+    return `${CATEGORY_META[origin.category].title}, page ${origin.page + 1}`;
+  }
+  if (origin.type === "file-browser") {
+    return origin.path ? `File browser: ${origin.path}` : "File browser root";
+  }
+  return "Launcher";
+}
+
+function createGalleryItemTarget(item, position, onActivate) {
+  const kind = resolveItemKind(item);
+  const meta = kindMeta(kind);
+  const symbolBuilder =
+    kind === "model"
+      ? buildModelSymbol
+      : kind === "text"
+        ? buildTextSymbol
+        : kind === "audio"
+          ? buildAudioSymbol
+          : kind === "directory"
+            ? buildFolderSymbol
+            : buildUnsupportedSymbol;
+  const group = buildInteractiveTile(item.title, symbolBuilder, meta.color);
+  createTarget({
+    id: `item-${item.slug}`,
+    title: item.title,
+    type: meta.title,
+    actionLabel: meta.actionLabel,
+    group,
+    position,
+    radius: 0.52,
+    onActivate,
+    color: meta.color,
+  });
+}
+
+function addControlTarget({
+  id,
+  label,
+  type,
+  actionLabel,
+  kind,
+  color,
+  position,
+  onActivate,
+  disabled = false,
+}) {
+  const group = buildControlButton(kind, color, disabled);
+  addFloatingLabel(group, label, 0.42, disabled ? "#6e7681" : "#8b949e");
+  createTarget({
+    id,
+    title: label,
+    type,
+    actionLabel,
+    group,
+    position,
+    radius: 0.34,
+    onActivate,
+    color,
+    disabled,
+  });
+}
+
+async function loadWorkspaceCatalog() {
+  const payload = await fetchJson(workspaceCatalogUrl);
+  state.workspaceCatalog = payload.workspaces;
+  buildWorkspaceSelect();
+  if (state.workspaceCatalog.length === 0) {
+    throw new Error("No Haptic Desktop workspace descriptors are available.");
+  }
+  return payload;
+}
+
+async function loadWorkspaceBySlug(slug) {
+  const workspace = await fetchJson(workspaceDetailUrl(slug));
+  state.activeWorkspace = workspace;
+  updateWorkspaceSummary();
+  publishStatus(`Workspace ${workspace.title} loaded.`, "Ready", `workspace-${workspace.slug}`);
+  await navigateToLauncher();
+}
+
+async function navigateToLauncher() {
+  const token = beginSceneBuild("workspace launcher");
+  const workspace = state.activeWorkspace;
+  prepareScene(
+    5.2,
+    4.2,
+    workspace.title,
+    "Scene 1: tactile launcher with direct access to curated galleries and file browsing.",
+  );
+
+  [
+    {
+      id: "launcher-models",
+      title: "Models Gallery",
+      type: "Launcher",
+      actionLabel: "Open the 3D model gallery",
+      color: CATEGORY_META.models.color,
+      symbolBuilder: buildModelSymbol,
+      position: new THREE.Vector3(-1.25, 0.12, -0.72),
+      onActivate: async () => navigateToGallery("models", 0),
+    },
+    {
+      id: "launcher-texts",
+      title: "Text Library",
+      type: "Launcher",
+      actionLabel: "Open the text gallery",
+      color: CATEGORY_META.texts.color,
+      symbolBuilder: buildTextSymbol,
+      position: new THREE.Vector3(1.25, 0.12, -0.72),
+      onActivate: async () => navigateToGallery("texts", 0),
+    },
+    {
+      id: "launcher-audio",
+      title: "Audio Library",
+      type: "Launcher",
+      actionLabel: "Open the audio gallery",
+      color: CATEGORY_META.audio.color,
+      symbolBuilder: buildAudioSymbol,
+      position: new THREE.Vector3(-1.25, 0.12, 0.92),
+      onActivate: async () => navigateToGallery("audio", 0),
+    },
+    {
+      id: "launcher-files",
+      title: "File Browser",
+      type: "Launcher",
+      actionLabel: "Open workspace file navigation",
+      color: 0xc297ff,
+      symbolBuilder: buildFolderSymbol,
+      position: new THREE.Vector3(1.25, 0.12, 0.92),
+      onActivate: async () => navigateToFileBrowser("", 0),
+    },
+  ].forEach((item) => {
+    const group = buildInteractiveTile(item.title, item.symbolBuilder, item.color);
+    createTarget({
+      id: item.id,
+      title: item.title,
+      type: item.type,
+      actionLabel: item.actionLabel,
+      group,
+      position: item.position,
+      radius: 0.56,
+      onActivate: item.onActivate,
+      color: item.color,
+    });
+  });
+
+  const info = createLabelSprite(
+    `Models ${workspace.libraries.models.length} | Texts ${workspace.libraries.texts.length} | Audio ${workspace.libraries.audio.length}`,
+    {
+      background: "rgba(13, 17, 23, 0.72)",
+      color: "#8b949e",
+      fontSize: 15,
+    },
+  );
+  info.position.set(0, 0.3, 1.52);
+  state.sceneApi.world.add(info);
+
+  state.pointerController.setBounds(
+    new THREE.Vector3(-2.2, 0.14, -1.6),
+    new THREE.Vector3(2.2, 1.1, 1.8),
+  );
+  state.pointerController.setPosition(new THREE.Vector3(-1.25, 0.36, -0.4));
+  assertSceneToken(token);
+  finishSceneBuild({
+    code: "launcher",
+    title: "Workspace Launcher",
+    subtitle: "Tactile launcher for curated models, text, audio, and direct file browsing.",
+    context: workspace.title,
+    path: workspace.file_browser.root_path_hint,
+    pagination: "1 / 1",
+    idleMessage: "Pointer moving across the launcher scene.",
+  });
+  focusTarget("launcher-models", { source: "scene", movePointer: false });
+}
+
+async function navigateToGallery(category, page = 0) {
+  const token = beginSceneBuild(`${CATEGORY_META[category].title.toLowerCase()}`);
+  const workspace = state.activeWorkspace;
+  const pageSlice = slicePage(workspace.libraries[category], GALLERY_PAGE_SIZE, page);
+  prepareScene(
+    5.8,
+    4.5,
+    CATEGORY_META[category].title,
+    `Scene 2: paginated tactile gallery for ${category}.`,
+    [5.2, 3.4, 5.4],
+    [0, 0.28, 0.16],
+  );
+
+  const positions = galleryTilePositions(pageSlice.items.length);
+  pageSlice.items.forEach((item, index) => {
+    createGalleryItemTarget(item, positions[index], async () =>
+      navigateToDetail(item, { type: "gallery", category, page: pageSlice.page }),
+    );
+  });
+
+  addControlTarget({
+    id: `gallery-${category}-home`,
+    label: "Home",
+    type: "Control",
+    actionLabel: "Return to the launcher",
+    kind: "home",
+    color: 0x39d2c0,
+    position: new THREE.Vector3(-1.45, 0.12, 1.78),
+    onActivate: async () => navigateToLauncher(),
+  });
+  addControlTarget({
+    id: `gallery-${category}-prev`,
+    label: "Previous",
+    type: "Control",
+    actionLabel: "Move to the previous gallery page",
+    kind: "previous",
+    color: CATEGORY_META[category].color,
+    position: new THREE.Vector3(-0.3, 0.12, 1.78),
+    onActivate: async () => navigateToGallery(category, pageSlice.page - 1),
+    disabled: pageSlice.page === 0,
+  });
+  addControlTarget({
+    id: `gallery-${category}-next`,
+    label: "Next",
+    type: "Control",
+    actionLabel: "Move to the next gallery page",
+    kind: "next",
+    color: CATEGORY_META[category].color,
+    position: new THREE.Vector3(0.86, 0.12, 1.78),
+    onActivate: async () => navigateToGallery(category, pageSlice.page + 1),
+    disabled: pageSlice.page >= pageSlice.pageCount - 1,
+  });
+
+  state.pointerController.setBounds(
+    new THREE.Vector3(-2.4, 0.14, -1.6),
+    new THREE.Vector3(2.4, 1.1, 2.0),
+  );
+  state.pointerController.setPosition(
+    positions[0]?.clone().setY(0.36) ?? new THREE.Vector3(-1.45, 0.36, 1.3),
+  );
+  assertSceneToken(token);
+  finishSceneBuild({
+    code: CATEGORY_META[category].sceneCode,
+    title: CATEGORY_META[category].title,
+    subtitle: CATEGORY_META[category].description,
+    context: workspace.title,
+    path: CATEGORY_META[category].title,
+    pagination: `${pageSlice.page + 1} / ${pageSlice.pageCount}`,
+    idleMessage: `Pointer moving across the ${CATEGORY_META[category].title.toLowerCase()}.`,
+  });
+  focusTarget(
+    pageSlice.items.length > 0 ? `item-${pageSlice.items[0].slug}` : `gallery-${category}-home`,
+    { source: "scene", movePointer: false },
+  );
+}
+
+async function navigateToFileBrowser(relativePath = "", page = 0) {
+  const token = beginSceneBuild("file browser");
+  const workspace = state.activeWorkspace;
+  const payload = await fetchJson(workspaceBrowseUrl(workspace.slug, relativePath));
+  const pageSlice = slicePage(payload.entries, FILE_BROWSER_PAGE_SIZE, page);
+  prepareScene(
+    5.8,
+    4.5,
+    "Workspace File Browser",
+    "Scene 2: tactile filesystem navigation rooted in the active workspace.",
+    [5.2, 3.4, 5.4],
+    [0, 0.28, 0.16],
+  );
+
+  const positions = galleryTilePositions(pageSlice.items.length);
+  pageSlice.items.forEach((entry, index) => {
+    const onActivate =
+      entry.kind === "directory"
+        ? async () => navigateToFileBrowser(entry.relative_path, 0)
+        : async () =>
+            navigateToDetail(
+              {
+                ...entry,
+                source: entry.source ?? {
+                  kind: "workspace_file",
+                  relative_path: entry.relative_path,
+                },
+              },
+              { type: "file-browser", path: payload.current_path, page: pageSlice.page },
+            );
+    createGalleryItemTarget(entry, positions[index], onActivate);
+    const target = state.targets.get(`item-${entry.slug}`);
+    target.actionLabel = entry.kind === "directory" ? "Open folder" : target.actionLabel;
+  });
+
+  addControlTarget({
+    id: "file-browser-home",
+    label: "Home",
+    type: "Control",
+    actionLabel: "Return to the launcher",
+    kind: "home",
+    color: 0x39d2c0,
+    position: new THREE.Vector3(-1.72, 0.12, 1.78),
+    onActivate: async () => navigateToLauncher(),
+  });
+  addControlTarget({
+    id: "file-browser-up",
+    label: "Up",
+    type: "Control",
+    actionLabel: "Return to the parent folder",
+    kind: "up",
+    color: 0xc297ff,
+    position: new THREE.Vector3(-0.58, 0.12, 1.78),
+    onActivate: async () => navigateToFileBrowser(payload.parent_path ?? "", 0),
+    disabled: !payload.parent_path,
+  });
+  addControlTarget({
+    id: "file-browser-prev",
+    label: "Previous",
+    type: "Control",
+    actionLabel: "Move to the previous file page",
+    kind: "previous",
+    color: 0x58a6ff,
+    position: new THREE.Vector3(0.56, 0.12, 1.78),
+    onActivate: async () => navigateToFileBrowser(payload.current_path, pageSlice.page - 1),
+    disabled: pageSlice.page === 0,
+  });
+  addControlTarget({
+    id: "file-browser-next",
+    label: "Next",
+    type: "Control",
+    actionLabel: "Move to the next file page",
+    kind: "next",
+    color: 0x58a6ff,
+    position: new THREE.Vector3(1.7, 0.12, 1.78),
+    onActivate: async () => navigateToFileBrowser(payload.current_path, pageSlice.page + 1),
+    disabled: pageSlice.page >= pageSlice.pageCount - 1,
+  });
+
+  state.pointerController.setBounds(
+    new THREE.Vector3(-2.5, 0.14, -1.6),
+    new THREE.Vector3(2.5, 1.1, 2.0),
+  );
+  state.pointerController.setPosition(
+    positions[0]?.clone().setY(0.36) ?? new THREE.Vector3(-1.72, 0.36, 1.3),
+  );
+  assertSceneToken(token);
+  finishSceneBuild({
+    code: "file-browser",
+    title: "Workspace File Browser",
+    subtitle: "Directory buttons, supported-file buttons, and unsupported-file placeholders share the same bounded tactile map.",
+    context: workspace.title,
+    path: payload.current_path || payload.current_label,
+    pagination: `${pageSlice.page + 1} / ${pageSlice.pageCount}`,
+    idleMessage: "Pointer moving across the workspace file browser.",
+  });
+  focusTarget(
+    pageSlice.items.length > 0 ? `item-${pageSlice.items[0].slug}` : "file-browser-home",
+    { source: "scene", movePointer: false },
+  );
+}
+
+function truncateDetailText(text) {
+  return text.length > 24 ? `${text.slice(0, 24)}…` : text;
+}
+
+async function navigateBackToOrigin(origin) {
+  if (!origin) {
+    await navigateToLauncher();
     return;
   }
-  state.focusIndex = state.hoveredIndex;
-  activateFocusedItem(sceneApi, "pointer");
+  if (origin.type === "gallery") {
+    await navigateToGallery(origin.category, origin.page);
+    return;
+  }
+  if (origin.type === "file-browser") {
+    await navigateToFileBrowser(origin.path ?? "", origin.page ?? 0);
+    return;
+  }
+  await navigateToLauncher();
+}
+
+async function navigateToDetail(item, origin) {
+  const token = beginSceneBuild("content detail");
+  const kind = resolveItemKind(item);
+  const meta = kindMeta(kind);
+  const preview = await fetchBraillePreview(truncateDetailText(item.title), DETAIL_BRAILLE_COLUMNS);
+
+  prepareScene(
+    5.0,
+    4.0,
+    item.title,
+    "Scene 3: tactile detail plaque with braille naming and open controls.",
+    [4.6, 3.0, 4.6],
+    [0, 0.28, 0],
+  );
+
+  const plaque = buildBraillePlaque(preview.cells, DETAIL_BRAILLE_COLUMNS, {
+    maxRows: 2,
+    spacingX: 0.25,
+    spacingZ: 0.34,
+    surfaceColor: 0x16213a,
+  });
+  plaque.position.set(-0.2, 0.12, -0.22);
+  state.sceneApi.world.add(plaque);
+
+  const symbolBuilder =
+    kind === "model"
+      ? buildModelSymbol
+      : kind === "text"
+        ? buildTextSymbol
+        : kind === "audio"
+          ? buildAudioSymbol
+          : buildUnsupportedSymbol;
+  const icon = buildInteractiveTile(meta.title, symbolBuilder, meta.color);
+  icon.position.set(1.6, 0.12, -0.2);
+  icon.scale.setScalar(0.92);
+  state.sceneApi.world.add(icon);
+
+  const summarySprite = createLabelSprite(item.summary || "No description recorded.", {
+    background: "rgba(13, 17, 23, 0.72)",
+    color: "#8b949e",
+    fontSize: 15,
+  });
+  summarySprite.position.set(0, 0.32, 1.18);
+  state.sceneApi.world.add(summarySprite);
+
+  addControlTarget({
+    id: "detail-home",
+    label: "Home",
+    type: "Control",
+    actionLabel: "Return to the launcher",
+    kind: "home",
+    color: 0x39d2c0,
+    position: new THREE.Vector3(-1.4, 0.12, 1.42),
+    onActivate: async () => navigateToLauncher(),
+  });
+  addControlTarget({
+    id: "detail-back",
+    label: "Back",
+    type: "Control",
+    actionLabel: `Return to ${detailOriginLabel(origin)}`,
+    kind: "back",
+    color: 0x58a6ff,
+    position: new THREE.Vector3(-0.1, 0.12, 1.42),
+    onActivate: async () => navigateBackToOrigin(origin),
+  });
+  addControlTarget({
+    id: "detail-open",
+    label: kind === "unsupported" ? "Unavailable" : "Open",
+    type: "Control",
+    actionLabel: kind === "unsupported" ? "The selected file is not supported yet" : `Open ${item.title}`,
+    kind: "open",
+    color: meta.color,
+    position: new THREE.Vector3(1.2, 0.12, 1.42),
+    onActivate: async () => openItemScene(item, origin),
+    disabled: kind === "unsupported",
+  });
+
+  state.pointerController.setBounds(
+    new THREE.Vector3(-2.2, 0.14, -1.4),
+    new THREE.Vector3(2.2, 1.0, 1.7),
+  );
+  state.pointerController.setPosition(new THREE.Vector3(-0.1, 0.34, 1.0));
+  assertSceneToken(token);
+  finishSceneBuild({
+    code: `detail-${kind}`,
+    title: `${meta.title} Detail`,
+    subtitle: "Item naming is represented as a tactile plaque before opening the content scene.",
+    context: detailOriginLabel(origin),
+    path:
+      item.source?.relative_path ??
+      item.source?.document_slug ??
+      item.source?.audio_slug ??
+      item.source?.demo_model_slug ??
+      item.slug,
+    pagination: "1 / 1",
+    idleMessage: `Pointer moving across the detail scene for ${item.title}.`,
+  });
+  focusTarget("detail-open", { source: "scene", movePointer: false });
+  publishStatus(`${item.title}. ${item.summary || meta.title}.`, "Ready", `detail-${item.slug}`);
+}
+
+async function loadObj(url) {
+  return new Promise((resolve, reject) => {
+    state.loader.load(url, resolve, undefined, reject);
+  });
+}
+
+async function navigateToModelScene(item, origin) {
+  const token = beginSceneBuild("model scene");
+  prepareScene(
+    6.2,
+    4.8,
+    item.title,
+    "Scene 4: bounded model exploration with direct tactile return controls.",
+    [5.2, 3.8, 6.2],
+    [0, 0.72, 0],
+  );
+
+  const object = await loadObj(itemRawFileUrl(item));
+  object.traverse((node) => {
+    if (node.isMesh) {
+      node.material = new THREE.MeshStandardMaterial({
+        color: 0x6f8fb4,
+        roughness: 0.6,
+        metalness: 0.08,
+        emissive: 0x0b1522,
+      });
+    }
+  });
+
+  const plinth = new THREE.Mesh(
+    new THREE.CylinderGeometry(1.42, 1.52, 0.12, 36),
+    new THREE.MeshStandardMaterial({
+      color: 0x0f1724,
+      roughness: 0.9,
+      metalness: 0.06,
+      emissive: 0x08111a,
+    }),
+  );
+  plinth.position.y = 0.06;
+  state.sceneApi.world.add(plinth);
+  state.sceneApi.world.add(object);
+  state.sceneApi.normalizeObject(object, 2.4);
+  object.position.y += 0.16;
+  state.sceneApi.frameObject(object, 5.6);
+
+  const bounds = new THREE.Box3().setFromObject(object);
+  const size = bounds.getSize(new THREE.Vector3());
+  const center = bounds.getCenter(new THREE.Vector3());
+
+  addControlTarget({
+    id: "model-home",
+    label: "Home",
+    type: "Control",
+    actionLabel: "Return to the launcher",
+    kind: "home",
+    color: 0x39d2c0,
+    position: new THREE.Vector3(-1.5, 0.12, 1.7),
+    onActivate: async () => navigateToLauncher(),
+  });
+  addControlTarget({
+    id: "model-back",
+    label: "Back",
+    type: "Control",
+    actionLabel: `Return to ${detailOriginLabel(origin)}`,
+    kind: "back",
+    color: 0x58a6ff,
+    position: new THREE.Vector3(0, 0.12, 1.7),
+    onActivate: async () => navigateBackToOrigin(origin),
+  });
+
+  state.sceneApi.setBoundarySize(
+    new THREE.Vector3(
+      Math.max(5.6, size.x + 2.4),
+      Math.max(2.6, size.y + 1.2),
+      Math.max(4.8, size.z + 3.0),
+    ),
+  );
+  state.pointerController.setBounds(
+    new THREE.Vector3(center.x - size.x * 0.72, 0.14, -1.8),
+    new THREE.Vector3(center.x + size.x * 0.72, Math.max(1.8, size.y + 0.9), 2.1),
+  );
+  state.pointerController.setPosition(
+    new THREE.Vector3(center.x + 0.8, Math.min(size.y + 0.5, 1.25), 0.6),
+  );
+  assertSceneToken(token);
+  finishSceneBuild({
+    code: "open-model",
+    title: "3D Model Scene",
+    subtitle: "The opened object shares space with tactile home and gallery-return controls.",
+    context: detailOriginLabel(origin),
+    path: item.source?.relative_path ?? item.source?.demo_model_slug ?? item.slug,
+    pagination: "1 / 1",
+    idleMessage: `Pointer moving across the opened 3D model ${item.title}.`,
+  });
+  focusTarget("model-back", { source: "scene", movePointer: false });
+  publishStatus(`Opened ${item.title} in the model scene.`, "Ready", `open-model-${item.slug}`);
+}
+
+function textPageCount(textScene) {
+  const maxRow = textScene.cells.length ? Math.max(...textScene.cells.map((cell) => cell.row)) + 1 : 0;
+  return Math.max(1, Math.ceil(maxRow / TEXT_ROWS_PER_PAGE));
+}
+
+function textPageCells(textScene) {
+  const rowStart = textScene.page * TEXT_ROWS_PER_PAGE;
+  const rowEnd = rowStart + TEXT_ROWS_PER_PAGE;
+  return textScene.cells
+    .filter((cell) => cell.row >= rowStart && cell.row < rowEnd)
+    .map((cell) => ({ ...cell, localRow: cell.row - rowStart }));
+}
+
+function buildTextBoard(pageCells) {
+  const width = Math.max(2.4, TEXT_COLUMNS * 0.34 + 0.8);
+  const depth = Math.max(1.9, TEXT_ROWS_PER_PAGE * 0.48 + 1.12);
+  const group = new THREE.Group();
+
+  const base = new THREE.Mesh(
+    new THREE.BoxGeometry(width, 0.12, depth),
+    new THREE.MeshStandardMaterial({
+      color: 0x16213a,
+      roughness: 0.9,
+      metalness: 0.05,
+      emissive: 0x08111a,
+    }),
+  );
+  base.position.y = 0.06;
+  group.add(base);
+
+  const leftRail = new THREE.Mesh(
+    new THREE.BoxGeometry(0.1, 0.08, depth - 0.16),
+    new THREE.MeshStandardMaterial({
+      color: 0x0f1724,
+      roughness: 0.88,
+      metalness: 0.04,
+      emissive: 0x08111a,
+    }),
+  );
+  leftRail.position.set(-width / 2 + 0.1, 0.1, -0.02);
+  group.add(leftRail);
+
+  const frontLip = new THREE.Mesh(
+    new THREE.BoxGeometry(width - 0.2, 0.06, 0.08),
+    new THREE.MeshStandardMaterial({
+      color: 0x111827,
+      roughness: 0.86,
+      metalness: 0.04,
+      emissive: 0x08111a,
+    }),
+  );
+  frontLip.position.set(0, 0.085, depth / 2 - 0.14);
+  group.add(frontLip);
+
+  const orientation = new THREE.Mesh(
+    new THREE.ConeGeometry(0.08, 0.14, 3),
+    new THREE.MeshStandardMaterial({
+      color: 0xf2cc60,
+      roughness: 0.34,
+      metalness: 0.04,
+      emissive: 0x4a2d00,
+    }),
+  );
+  orientation.rotation.y = Math.PI;
+  orientation.position.set(-width / 2 + 0.18, 0.14, -depth / 2 + 0.22);
+  group.add(orientation);
+
+  pageCells.forEach((cell) => {
+    const cellGroup = createBrailleCellGroup(cell, TEXT_COLUMNS, 0, {
+      spacingX: 0.34,
+      spacingZ: 0.48,
+      baseColor: 0x111827,
+      dotColor: 0xf2cc60,
+    });
+    cellGroup.position.y = 0.12;
+    cellGroup.position.z -= ((TEXT_ROWS_PER_PAGE - 1) * 0.48) / 2 + 0.18;
+    group.add(cellGroup);
+  });
+
+  return { group, width, depth };
+}
+
+async function loadTextScene(item, origin, offset = 0) {
+  const maxChars = Number(byId("desktop-text-segment-size").value) || 1200;
+  const payload = await fetchJson(itemTextEndpoint(item, offset, maxChars));
+  const preview = await fetchBraillePreview(payload.text, TEXT_COLUMNS);
+  state.textScene = {
+    item,
+    origin,
+    payload,
+    cells: preview.cells,
+    page: 0,
+  };
+}
+
+function renderTextScene(token = state.sceneBuildToken) {
+  assertSceneToken(token);
+  const textScene = state.textScene;
+  const pageCells = textPageCells(textScene);
+  const board = buildTextBoard(pageCells);
+  prepareScene(
+    5.2,
+    4.2,
+    textScene.item.title,
+    "Scene 4: tactile Braille reading board with gallery and launcher return controls.",
+    [3.2, 2.8, 4.2],
+    [0, 0.18, 0.16],
+  );
+
+  state.sceneApi.world.add(board.group);
+  const header = createLabelSprite(
+    `${textScene.payload.offset + 1} - ${textScene.payload.offset + textScene.payload.loaded_characters} / ${textScene.payload.total_characters}`,
+    {
+      background: "rgba(13, 17, 23, 0.74)",
+      color: "#8b949e",
+      fontSize: 15,
+    },
+  );
+  header.position.set(0, 0.3, 1.44);
+  state.sceneApi.world.add(header);
+
+  addControlTarget({
+    id: "text-home",
+    label: "Home",
+    type: "Control",
+    actionLabel: "Return to the launcher",
+    kind: "home",
+    color: 0x39d2c0,
+    position: new THREE.Vector3(-1.58, 0.12, 1.78),
+    onActivate: async () => navigateToLauncher(),
+  });
+  addControlTarget({
+    id: "text-back",
+    label: "Back",
+    type: "Control",
+    actionLabel: `Return to ${detailOriginLabel(textScene.origin)}`,
+    kind: "back",
+    color: 0x58a6ff,
+    position: new THREE.Vector3(-0.44, 0.12, 1.78),
+    onActivate: async () => navigateBackToOrigin(textScene.origin),
+  });
+  addControlTarget({
+    id: "text-prev",
+    label: "Previous",
+    type: "Control",
+    actionLabel: "Move to the previous reading page",
+    kind: "previous",
+    color: 0x7ee787,
+    position: new THREE.Vector3(0.7, 0.12, 1.78),
+    onActivate: async () => moveTextScene(-1),
+    disabled: textScene.page === 0 && textScene.payload.previous_offset === null,
+  });
+  addControlTarget({
+    id: "text-next",
+    label: "Next",
+    type: "Control",
+    actionLabel: "Move to the next reading page",
+    kind: "next",
+    color: 0x7ee787,
+    position: new THREE.Vector3(1.84, 0.12, 1.78),
+    onActivate: async () => moveTextScene(1),
+    disabled:
+      textScene.page >= textPageCount(textScene) - 1 &&
+      textScene.payload.next_offset === null,
+  });
+
+  state.sceneApi.setBoundarySize(new THREE.Vector3(board.width + 1, 1.0, board.depth + 1.1));
+  state.pointerController.setBounds(
+    new THREE.Vector3(-board.width / 2, 0.14, -board.depth / 2 + 0.02),
+    new THREE.Vector3(board.width / 2, 0.34, 1.95),
+  );
+  state.pointerController.setPosition(new THREE.Vector3(-0.44, 0.24, 1.22));
+  finishSceneBuild({
+    code: "open-text",
+    title: "Text Reading Scene",
+    subtitle: "The reading surface, pagination, and return flow remain inside the bounded 3D scene.",
+    context: detailOriginLabel(textScene.origin),
+    path: textScene.item.source?.relative_path ?? textScene.item.source?.document_slug ?? textScene.item.slug,
+    pagination: `${textScene.page + 1} / ${textPageCount(textScene)}`,
+    idleMessage: `Pointer moving across the reading surface for ${textScene.item.title}.`,
+  });
+  focusTarget("text-next", { source: "scene", movePointer: false });
+}
+
+async function navigateToTextScene(item, origin, offset = 0) {
+  const token = beginSceneBuild("text scene");
+  await loadTextScene(item, origin, offset);
+  renderTextScene(token);
+  publishStatus(`Opened ${item.title} in the Braille reading scene.`, "Ready", `open-text-${item.slug}`);
+}
+
+async function moveTextScene(step) {
+  const textScene = state.textScene;
+  if (!textScene) {
+    return;
+  }
+  const pageCount = textPageCount(textScene);
+  if (step < 0) {
+    if (textScene.page > 0) {
+      textScene.page -= 1;
+      renderTextScene();
+      return;
+    }
+    if (textScene.payload.previous_offset !== null) {
+      await loadTextScene(textScene.item, textScene.origin, textScene.payload.previous_offset);
+      state.textScene.page = Math.max(0, textPageCount(state.textScene) - 1);
+      renderTextScene();
+      return;
+    }
+    publishStatus("The text scene is already at the first reading page.", "Ready", "text-first");
+    return;
+  }
+  if (textScene.page < pageCount - 1) {
+    textScene.page += 1;
+    renderTextScene();
+    return;
+  }
+  if (textScene.payload.next_offset !== null) {
+    await loadTextScene(textScene.item, textScene.origin, textScene.payload.next_offset);
+    renderTextScene();
+    return;
+  }
+  publishStatus("The text scene is already at the last reading page.", "Ready", "text-last");
+}
+
+function seekAudio(delta) {
+  const player = audioPlayer();
+  if (!player.src) {
+    return;
+  }
+  player.currentTime = Math.max(0, Math.min(player.duration || player.currentTime + delta, player.currentTime + delta));
+  updateAudioSession();
+}
+
+function renderAudioScene(token = state.sceneBuildToken) {
+  assertSceneToken(token);
+  const audioScene = state.audioScene;
+  const player = audioPlayer();
+  prepareScene(
+    5.2,
+    4.2,
+    audioScene.item.title,
+    "Scene 4: tactile audio transport with seek, return, and launcher controls.",
+    [4.8, 3.2, 5.0],
+    [0, 0.28, 0],
+    true,
+  );
+
+  const speaker = buildAudioSymbol(0xf2cc60);
+  speaker.position.set(0, 0.12, -0.22);
+  speaker.scale.setScalar(1.8);
+  state.sceneApi.world.add(speaker);
+  const transport = createLabelSprite(
+    `${formatSeconds(player.currentTime || 0)} / ${formatSeconds(player.duration)}`,
+    {
+      background: "rgba(13, 17, 23, 0.72)",
+      color: "#8b949e",
+      fontSize: 15,
+    },
+  );
+  transport.position.set(0, 0.34, 1.16);
+  state.sceneApi.world.add(transport);
+
+  addControlTarget({
+    id: "audio-home",
+    label: "Home",
+    type: "Control",
+    actionLabel: "Return to the launcher",
+    kind: "home",
+    color: 0x39d2c0,
+    position: new THREE.Vector3(-1.78, 0.12, 1.46),
+    onActivate: async () => navigateToLauncher(),
+  });
+  addControlTarget({
+    id: "audio-back",
+    label: "Back",
+    type: "Control",
+    actionLabel: `Return to ${detailOriginLabel(audioScene.origin)}`,
+    kind: "back",
+    color: 0x58a6ff,
+    position: new THREE.Vector3(-0.62, 0.12, 1.46),
+    onActivate: async () => navigateBackToOrigin(audioScene.origin),
+  });
+  addControlTarget({
+    id: "audio-toggle",
+    label: player.paused ? "Play" : "Pause",
+    type: "Control",
+    actionLabel: player.paused ? "Start playback" : "Pause playback",
+    kind: "playpause",
+    color: 0xf2cc60,
+    position: new THREE.Vector3(0.54, 0.12, 1.46),
+    onActivate: async () => {
+      if (player.paused) {
+        await player.play();
+      } else {
+        player.pause();
+      }
+      renderAudioScene();
+    },
+  });
+  addControlTarget({
+    id: "audio-seek-back",
+    label: "Back 10s",
+    type: "Control",
+    actionLabel: "Seek backward ten seconds",
+    kind: "seek-back",
+    color: 0xf2cc60,
+    position: new THREE.Vector3(1.7, 0.12, 1.46),
+    onActivate: async () => {
+      seekAudio(-SEEK_SECONDS);
+      renderAudioScene();
+    },
+  });
+  addControlTarget({
+    id: "audio-seek-forward",
+    label: "Forward 10s",
+    type: "Control",
+    actionLabel: "Seek forward ten seconds",
+    kind: "seek-forward",
+    color: 0xf2cc60,
+    position: new THREE.Vector3(2.86, 0.12, 1.46),
+    onActivate: async () => {
+      seekAudio(SEEK_SECONDS);
+      renderAudioScene();
+    },
+  });
+
+  state.pointerController.setBounds(
+    new THREE.Vector3(-2.3, 0.14, -1.5),
+    new THREE.Vector3(3.3, 1.0, 1.7),
+  );
+  state.pointerController.setPosition(new THREE.Vector3(0.54, 0.3, 1.08));
+  finishSceneBuild({
+    code: "open-audio",
+    title: "Audio Scene",
+    subtitle: "Playback control is expressed as tactile objects in the same 3D scene.",
+    context: detailOriginLabel(audioScene.origin),
+    path: audioScene.item.source?.relative_path ?? audioScene.item.source?.audio_slug ?? audioScene.item.slug,
+    pagination: "1 / 1",
+    idleMessage: `Pointer moving across the audio scene for ${audioScene.item.title}.`,
+  });
+  focusTarget("audio-toggle", { source: "scene", movePointer: false });
+}
+
+async function navigateToAudioScene(item, origin) {
+  const token = beginSceneBuild("audio scene");
+  const player = audioPlayer();
+  player.src = itemRawFileUrl(item);
+  player.load();
+  state.audioScene = { item, origin };
+  updateAudioSession(item);
+  renderAudioScene(token);
+  publishStatus(`Opened ${item.title} in the audio transport scene.`, "Ready", `open-audio-${item.slug}`);
+}
+
+async function openItemScene(item, origin) {
+  const kind = resolveItemKind(item);
+  if (kind === "model") {
+    await navigateToModelScene(item, origin);
+    return;
+  }
+  if (kind === "text") {
+    await navigateToTextScene(item, origin);
+    return;
+  }
+  if (kind === "audio") {
+    await navigateToAudioScene(item, origin);
+    return;
+  }
+  publishStatus(`${item.title} is not a supported content type yet.`, "Ready", `unsupported-${item.slug}`);
+}
+
+function bindFallbackControls() {
+  byId("focus-prev").addEventListener("click", () => moveFallbackFocus(-1));
+  byId("focus-next").addEventListener("click", () => moveFallbackFocus(1));
+  byId("focus-activate").addEventListener("click", () => {
+    activateFocusedTarget("fallback").catch((error) =>
+      publishStatus(error.message, "Error", "fallback-activate-error"),
+    );
+  });
+
+  byId("pointer-toggle").addEventListener("change", (event) => {
+    state.sceneApi.setPointerVisible(event.target.checked);
+  });
+  byId("audio-cues-toggle").addEventListener("change", (event) => {
+    state.speechEnabled = event.target.checked;
+    if (!state.speechEnabled && "speechSynthesis" in window) {
+      window.speechSynthesis.cancel();
+    }
+    byId("desktop-audio-state").textContent = state.audioScene
+      ? audioPlayer().paused
+        ? "Paused"
+        : "Playing"
+      : event.target.checked
+        ? "On"
+        : "Off";
+    publishStatus(
+      event.target.checked ? "Spoken cue announcements enabled." : "Spoken cue announcements disabled.",
+      "Ready",
+      event.target.checked ? "speech-on" : "speech-off",
+      { speakMessage: false },
+    );
+  });
+  byId("load-desktop-workspace").addEventListener("click", () => {
+    loadWorkspaceBySlug(currentSelectedWorkspaceSlug()).catch((error) =>
+      publishStatus(error.message, "Error", "load-workspace-error"),
+    );
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (
+      event.target instanceof HTMLElement &&
+      ["INPUT", "TEXTAREA", "SELECT", "OPTION"].includes(event.target.tagName)
+    ) {
+      return;
+    }
+    if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+      event.preventDefault();
+      moveFallbackFocus(-1);
+    }
+    if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+      event.preventDefault();
+      moveFallbackFocus(1);
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      activateFocusedTarget("fallback").catch((error) =>
+        publishStatus(error.message, "Error", "keyboard-activate-error"),
+      );
+    }
+  });
 }
 
 document.addEventListener("DOMContentLoaded", () => {
@@ -507,56 +2094,39 @@ document.addEventListener("DOMContentLoaded", () => {
       pageStatusId: "desktop-page-status",
       pageStatusText: "Boot failed",
       stageStatusId: "desktop-status-bar",
-      summaryIds: ["desktop-focus-label", "desktop-focus-type", "desktop-focus-action", "desktop-announcement"],
+      summaryIds: [
+        "desktop-scene-label",
+        "desktop-scene-context",
+        "desktop-scene-path",
+        "desktop-announcement",
+      ],
     },
     async () => {
-      const sceneApi = createWorkspaceScene(byId("desktop-canvas"), {
-        cameraPosition: [4.2, 3.0, 4.2],
-        target: [0, 0.38, 0],
-        boundarySize: new THREE.Vector3(5.0, 1.4, 3.8),
+      state.sceneApi = createWorkspaceScene(byId("desktop-canvas"), {
+        cameraPosition: [4.9, 3.2, 5.1],
+        target: [0, 0.28, 0.08],
+        boundarySize: new THREE.Vector3(6, 1.8, 5),
       });
 
-      state.pointerController = attachPointerEmulation(sceneApi, {
-        initialPosition: new THREE.Vector3(-1.1, 0.72, -0.2),
-        boundsMin: new THREE.Vector3(-2.1, 0.18, -1.55),
-        boundsMax: new THREE.Vector3(2.1, 0.95, 1.55),
+      state.pointerController = attachPointerEmulation(state.sceneApi, {
+        initialPosition: new THREE.Vector3(-1.25, 0.36, -0.4),
+        boundsMin: new THREE.Vector3(-2.4, 0.14, -1.8),
+        boundsMax: new THREE.Vector3(2.4, 1.1, 1.9),
         speed: 1.7,
-        onMove: (position) => updatePointerFocus(sceneApi, position),
-        onActivate: () => activatePointerTarget(sceneApi),
+        onMove: (position) => updatePointerHover(position),
+        onActivate: () => {
+          activateFocusedTarget("pointer").catch((error) =>
+            publishStatus(error.message, "Error", "pointer-activate-error"),
+          );
+        },
       });
 
-      renderLayout(sceneApi);
-
-      byId("focus-prev").addEventListener("click", () => moveFocus(sceneApi, -1));
-      byId("focus-next").addEventListener("click", () => moveFocus(sceneApi, 1));
-      byId("focus-activate").addEventListener("click", () => activateFocusedItem(sceneApi, "fallback"));
-
-      byId("layout-preset").addEventListener("change", (event) => {
-        state.layout = event.target.value;
-        renderLayout(sceneApi);
-        announce(`Layout preset changed to ${event.target.value}.`);
-      });
-
-      byId("audio-cues-toggle").addEventListener("change", (event) => {
-        byId("desktop-audio-state").textContent = event.target.checked ? "On" : "Off";
-        announce(event.target.checked ? "Audio cue labels enabled." : "Audio cue labels disabled.");
-      });
-
-      byId("pointer-toggle").addEventListener("change", (event) => {
-        sceneApi.setPointerVisible(event.target.checked);
-      });
-
-      document.addEventListener("keydown", (event) => {
-        if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
-          moveFocus(sceneApi, -1);
-        }
-        if (event.key === "ArrowRight" || event.key === "ArrowDown") {
-          moveFocus(sceneApi, 1);
-        }
-        if (event.key === "Enter") {
-          activateFocusedItem(sceneApi, "fallback");
-        }
-      });
+      bindAudioPlayer();
+      bindFallbackControls();
+      updateWorkspaceSummary();
+      updateSceneSummary();
+      await loadWorkspaceCatalog();
+      await loadWorkspaceBySlug(currentSelectedWorkspaceSlug());
     },
   );
 });

--- a/app/static/js/haptic_workspace_manager.js
+++ b/app/static/js/haptic_workspace_manager.js
@@ -1,0 +1,165 @@
+import { bootWorkspace } from "./app.js";
+
+const workspaceCatalogUrl = "/api/haptic-workspaces";
+const createWorkspaceUrl = "/api/haptic-workspaces/create";
+const registerWorkspaceUrl = "/api/haptic-workspaces/register";
+
+function byId(id) {
+  return document.getElementById(id);
+}
+
+const state = {
+  workspaces: [],
+  selectedSlug: null,
+};
+
+function setStatus(message, pillText = message) {
+  byId("manager-status-bar").textContent = message;
+  byId("manager-page-status").textContent = pillText;
+}
+
+function renderSelectedWorkspace(workspace) {
+  if (!workspace) {
+    byId("selected-workspace-title").textContent = "--";
+    byId("selected-workspace-source").textContent = "--";
+    byId("selected-workspace-models").textContent = "--";
+    byId("selected-workspace-texts").textContent = "--";
+    byId("selected-workspace-audio").textContent = "--";
+    return;
+  }
+
+  byId("selected-workspace-title").textContent = workspace.title;
+  byId("selected-workspace-source").textContent = workspace.registry_source;
+  byId("selected-workspace-models").textContent = String(workspace.category_counts.models);
+  byId("selected-workspace-texts").textContent = String(workspace.category_counts.texts);
+  byId("selected-workspace-audio").textContent = String(workspace.category_counts.audio);
+}
+
+function renderWorkspaceList() {
+  const container = byId("workspace-list");
+  container.innerHTML = "";
+
+  state.workspaces.forEach((workspace) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "workspace-card";
+    if (workspace.slug === state.selectedSlug) {
+      button.classList.add("is-selected");
+    }
+
+    const title = document.createElement("strong");
+    title.className = "workspace-card-title";
+    title.textContent = workspace.title;
+
+    const description = document.createElement("span");
+    description.className = "workspace-card-body";
+    description.textContent = workspace.description || "No description recorded.";
+
+    const meta = document.createElement("span");
+    meta.className = "workspace-card-meta";
+    meta.textContent =
+      `${workspace.registry_source} | models ${workspace.category_counts.models} | texts ${workspace.category_counts.texts} | audio ${workspace.category_counts.audio}`;
+
+    const path = document.createElement("span");
+    path.className = "workspace-card-path";
+    path.textContent = workspace.workspace_file_path;
+
+    button.append(title, description, meta, path);
+    button.addEventListener("click", () => {
+      state.selectedSlug = workspace.slug;
+      renderWorkspaceList();
+      renderSelectedWorkspace(workspace);
+      setStatus(`Selected workspace ${workspace.title}.`, "Selected");
+    });
+
+    container.appendChild(button);
+  });
+}
+
+async function fetchJson(url, options = {}) {
+  const response = await fetch(url, options);
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({}));
+    throw new Error(payload.detail || `Request failed: ${url}`);
+  }
+  return response.json();
+}
+
+async function refreshCatalog() {
+  const payload = await fetchJson(workspaceCatalogUrl);
+  state.workspaces = payload.workspaces;
+  state.selectedSlug = state.selectedSlug || payload.workspaces[0]?.slug || null;
+  byId("workspace-count").textContent = String(payload.workspaces.length);
+  byId("workspace-suffix").textContent = payload.workspace_suffix;
+  byId("workspace-registry-path").textContent = payload.registry_file_path;
+  renderWorkspaceList();
+  renderSelectedWorkspace(
+    state.workspaces.find((workspace) => workspace.slug === state.selectedSlug) ?? state.workspaces[0],
+  );
+  byId("manager-runtime-pill").textContent = "Registry ready";
+  setStatus("Workspace registry loaded.", "Ready");
+}
+
+async function createWorkspace() {
+  const payload = {
+    title: byId("workspace-title").value.trim(),
+    slug: byId("workspace-slug").value.trim() || null,
+    description: byId("workspace-description").value.trim(),
+    root_path: byId("workspace-root-path").value.trim(),
+    auto_populate: byId("workspace-auto-populate").checked,
+  };
+  const response = await fetchJson(createWorkspaceUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  byId("existing-workspace-path").value = response.workspace.workspace_file_path;
+  setStatus(`Created workspace ${response.workspace.title}.`, "Created");
+  await refreshCatalog();
+}
+
+async function registerWorkspace() {
+  const payload = {
+    workspace_file_path: byId("existing-workspace-path").value.trim(),
+  };
+  const response = await fetchJson(registerWorkspaceUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  setStatus(`Registered workspace ${response.workspace.title}.`, "Registered");
+  await refreshCatalog();
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  bootWorkspace(
+    {
+      title: "Haptic Workspace Manager startup failed",
+      runtimePillId: "manager-runtime-pill",
+      runtimePillText: "Runtime error",
+      pageStatusId: "manager-page-status",
+      pageStatusText: "Boot failed",
+      stageStatusId: "manager-status-bar",
+      summaryIds: [
+        "selected-workspace-title",
+        "selected-workspace-source",
+        "selected-workspace-models",
+        "selected-workspace-texts",
+        "selected-workspace-audio",
+      ],
+    },
+    async () => {
+      byId("create-workspace").addEventListener("click", () => {
+        createWorkspace().catch((error) => setStatus(error.message, "Create failed"));
+      });
+      byId("register-workspace").addEventListener("click", () => {
+        registerWorkspace().catch((error) => setStatus(error.message, "Register failed"));
+      });
+      byId("refresh-workspaces").addEventListener("click", () => {
+        refreshCatalog().catch((error) => setStatus(error.message, "Refresh failed"));
+      });
+
+      await refreshCatalog();
+    },
+  );
+});

--- a/app/static/object_explorer.html
+++ b/app/static/object_explorer.html
@@ -17,6 +17,7 @@
         <a class="mode-link is-active" href="/object-explorer">3D Object Explorer</a>
         <a class="mode-link" href="/braille-reader">Braille Reader</a>
         <a class="mode-link" href="/haptic-desktop">Haptic Desktop</a>
+        <a class="mode-link" href="/haptic-workspace-manager">Workspace Manager</a>
       </nav>
       <div class="header-tools">
         <span class="version-badge" data-runtime="version">v--</span>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,6 +32,7 @@ All user workspaces share:
 - a real 3D scene as the primary workspace for spatial modes
 - module-based frontend bootstrap through the shared shell helper
 - visible boot diagnostics when runtime initialization fails
+- workspace-driven scene transitions for Haptic Desktop
 
 Current shared files:
 
@@ -49,6 +50,7 @@ The user-facing interface is separated into dedicated routes:
 - `/object-explorer`
 - `/braille-reader`
 - `/haptic-desktop`
+- `/haptic-workspace-manager`
 
 This avoids collapsing incompatible workflows into one long page.
 
@@ -58,7 +60,7 @@ The object explorer, Braille reader, and haptic desktop each render an actual 3D
 
 - the object explorer stages real OBJ meshes inside a bounded scene
 - the Braille reader renders the tactile board as raised 3D geometry with scene-native navigation controls
-- the desktop mode renders shape-coded tactile objects inside a spatial desktop layout
+- the desktop mode renders a workspace-driven launcher, galleries, detail plaques, and opened content scenes
 - the shared pointer emulator behaves as a stylus-like proxy when no hardware device is attached
 
 Auxiliary 2D views are secondary and are only used when they help interpretation or debugging.
@@ -68,9 +70,11 @@ Auxiliary 2D views are secondary and are only used when they help interpretation
 - `app/static/object_explorer.html`
 - `app/static/braille_reader.html`
 - `app/static/haptic_desktop.html`
+- `app/static/haptic_workspace_manager.html`
 - `app/static/js/object_explorer.js`
 - `app/static/js/braille_reader.js`
 - `app/static/js/haptic_desktop.js`
+- `app/static/js/haptic_workspace_manager.js`
 - `app/static/vendor/three/OBJLoader.js`
 
 ## API Layer
@@ -87,6 +91,7 @@ Current responsibilities:
 - bundled document library catalog
 - bundled document segment loading
 - bundled audio library catalog
+- haptic workspace catalog, browsing, text loading, raw file serving, and descriptor management
 - haptic backend status
 - Braille preview translation
 
@@ -109,6 +114,7 @@ Current responsibilities:
 - bundled demo asset catalog
 - bundled public-domain document and audio catalogs
 - plain-text, HTML, and EPUB extraction for the internal reading library
+- haptic workspace descriptor parsing, registry, and filesystem browsing
 
 Current files:
 
@@ -119,6 +125,7 @@ Current files:
 - `app/core/haptic_materials.py`
 - `app/core/demo_assets.py`
 - `app/core/library_assets.py`
+- `app/core/haptic_workspace.py`
 
 ## Haptic Runtime Layer
 
@@ -156,11 +163,12 @@ Current file:
 4. The shared frontend shell requests `/api/health` and `/api/meta`.
 5. The object explorer additionally calls `/api/materials` and `/api/demo-models`.
 6. The Braille reader additionally calls `/api/library/documents` and `/api/library/audio`.
-7. Each workspace instantiates the shared stylus-like pointer proxy and bounded scene runtime.
-8. The object explorer stages an OBJ mesh and tactile material context on a visible exploration plinth.
-9. The Braille reader loads a bundled document segment, requests `/api/braille/preview`, and realizes the response as a 3D tactile board with in-scene controls.
-10. The desktop mode instantiates a bounded desktop scene from its local interaction model.
-11. Runtime and device status are reflected in the current workspace.
+7. Haptic Desktop calls `/api/haptic-workspaces` and resolves the selected `haptic_workspace`.
+8. Each spatial workspace instantiates the shared stylus-like pointer proxy and bounded scene runtime.
+9. The object explorer stages an OBJ mesh and tactile material context on a visible exploration plinth.
+10. The Braille reader loads a bundled document segment, requests `/api/braille/preview`, and realizes the response as a 3D tactile board with in-scene controls.
+11. Haptic Desktop moves between launcher, gallery, file-browser, detail, and opened-content scenes using workspace-driven payloads.
+12. Runtime and device status are reflected in the current workspace.
 
 ## Future Extension Points
 
@@ -203,17 +211,20 @@ Next additions:
 
 Current baseline:
 
-- 3D desktop object scene
-- focus traversal and activation prototype
-- shape-coded tactile object families instead of text-heavy world labels
-- announcement and inspector metadata outside the scene itself
+- structured `haptic_workspace` descriptor format and bundled demo workspace
+- dedicated manager route for creating and registering workspaces rooted in external folders
+- launcher scene for curated models, texts, audio, and file browsing
+- paginated gallery scenes for curated workspace content
+- file-browser scene rooted in the configured workspace path
+- detail plaque scene with braille naming before content opening
+- opened model, text, and audio scenes with scene-native return controls
 
 Next additions:
 
-- content graph or object catalog
-- audio label service
-- assistive focus and activation rules
-- integration with real desktop or curated content sources
+- richer workspace authoring tools and validation beyond the first JSON descriptor baseline
+- audio naming and cue refinement tied to real user workflows
+- assistive focus and activation rules tuned against real haptic-device constraints
+- integration with native hardware and richer desktop action execution
 
 ## Packaging Architecture
 

--- a/docs/development_history.md
+++ b/docs/development_history.md
@@ -15,6 +15,21 @@ The archived user manual describes the software as a digital-to-relief presentat
 
 ## Modern Rebuild Timeline
 
+### v0.5.0 (2026-03-29)
+
+Release focused on workspace-driven Haptic Desktop scenes, structured haptic_workspace descriptors, and the first external-workspace management flow.
+
+Delivered:
+
+- Added the haptic_workspace descriptor format, bundled demo workspace, external-root registry flow, and a dedicated Workspace Manager page.
+- Rebuilt Haptic Desktop around a scene graph with launcher, curated galleries, file-browser navigation, detail plaques, and opened scenes for models, text, and audio.
+- Expanded automated coverage with workspace-domain tests, API tests, and a stronger browser smoke validator for desktop workspace bootstrap.
+
+Rationale:
+
+- Shift Haptic Desktop from a static prototype into a real workspace-driven interaction model aligned with the project vision.
+- Treat structured workspace authoring, external asset roots, and blind-first scene transitions as product-level capabilities rather than future notes.
+
 ### v0.4.0 (2026-03-29)
 
 Release focused on the internal public-domain reading library, expanded demo assets, and stronger asset-validation coverage.
@@ -129,15 +144,15 @@ Rationale:
 
 ### v0.5.x
 
-- first native physical haptic bridge integration
-- device capability detection
-- hardware-assisted exploration loop
+- richer haptic_workspace authoring and validation
+- blind-first desktop help and cue refinement
+- stronger gallery and file-browser interaction coverage
 
 ### v0.6.x
 
-- haptic desktop content graph
-- audio labels and action objects
-- curated desktop interaction execution model
+- first native physical haptic bridge integration
+- device capability detection
+- hardware-assisted exploration loop
 
 ## Versioning Policy
 

--- a/docs/implementation_gap_audit.md
+++ b/docs/implementation_gap_audit.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document separates what FeelIT `0.4.0` demonstrably implements today from what remains partial, planned, or hardware-dependent.
+This document separates what FeelIT `0.5.0` demonstrably implements today from what remains partial, planned, or hardware-dependent.
 
 It is intentionally conservative. If a behavior is not visible in the runtime, testable through the current repo, or clearly encoded in the shipped code path, it is not treated here as delivered.
 
@@ -13,7 +13,7 @@ This audit is based on:
 - repository source inspection
 - API and unit tests from `tests/`
 - local browser smoke validation through `scripts/browser_scene_smoke.py`
-- visible runtime behavior in the three shipped workspaces
+- visible runtime behavior in the three shipped 3D workspaces plus the workspace manager route
 - preserved legacy evidence in `legacy/Registro Software`
 
 ## Delivered And Verifiable
@@ -25,10 +25,10 @@ Implemented:
 - FastAPI backend with public metadata, health, mode catalog, material catalog, demo-model catalog, and Braille preview endpoints
 - internal-library document and audio catalog endpoints for bundled public-domain assets
 - canonical semantic version source with synchronized README and Windows packaging metadata
-- three-mode frontend shell served from the backend on port `8101`
+- four-route frontend shell served from the backend on port `8101`
 - shared Three.js scene runtime with bounded workspace, orbit camera, and stylus-style pointer emulator
 - visual fallback execution when no haptic hardware is attached
-- browser smoke validation for the three primary 3D scenes
+- browser smoke validation for the three primary 3D scenes with desktop workspace bootstrap checks
 
 Notable evidence:
 
@@ -79,17 +79,22 @@ Still limited:
 
 Implemented:
 
-- bounded 3D desktop scene with six shape-coded tactile object families
-- pointer-driven focus and activation prototype
-- inspector and announcement surfaces outside the 3D world
-- layout presets for alternative desktop arrangements
+- structured `haptic_workspace` descriptor format with bundled demo workspace
+- dedicated workspace-manager route for creating and registering workspaces rooted in external folders
+- launcher scene for curated models, texts, audio, and workspace file browsing
+- paginated gallery scenes backed by workspace payloads
+- file-browser scene rooted in the configured workspace path
+- detail plaque scene that exposes the content name before opening it
+- opened scenes for 3D models, Braille reading, and audio transport
+- pointer-driven focus and activation across the current scene's tactile controls
 
 Still limited:
 
-- no real content graph behind the desktop objects
-- no actual file, media, or tool execution pipeline
-- no integrated audio playback or screen-reader bridge
-- no persistence or user-defined desktop layouts
+- no native hardware-backed haptic actuation yet
+- no richer workspace editor beyond the first descriptor-based manager route
+- no desktop-wide automation beyond curated content opening and file browsing
+- no support yet for unsupported file types beyond explicit placeholders
+- no real blind-user validation round on the new desktop scene flow
 
 ## Partial Or Prototype-Only Areas
 
@@ -123,7 +128,7 @@ The repository does not yet deliver:
 - runtime device capability detection beyond the null fallback report
 - full document-format compatibility beyond the current TXT, HTML, and EPUB baseline
 - server-side import and validation for 3D assets
-- real desktop action execution semantics
+- real desktop action execution semantics beyond content launching and playback control
 - hardware-backed tactile realization of the material profiles
 
 ## Legacy Alignment
@@ -147,4 +152,4 @@ Those belong to the modernization path, not to the verified archived implementat
 1. Build a first native backend integration boundary so the material and workspace models can move beyond visual approximation.
 2. Extend the Braille library with richer compatibility and blind-first scene-native library access.
 3. Extend the 3D asset pipeline with server-side validation and additional formats.
-4. Replace the desktop prototype labels and actions with a real content graph plus audio-assisted activation outcomes.
+4. Expand the workspace manager into a richer editor with descriptor validation, asset previews, and safer authoring affordances.

--- a/docs/library_catalog.md
+++ b/docs/library_catalog.md
@@ -8,6 +8,8 @@ This document summarizes the internal public-domain library currently bundled wi
 
 The internal library exists to make the Braille Reader immediately demonstrable without relying on ad hoc pasted text or remote network access during a session.
 
+The same internal assets now also seed the bundled demo `haptic_workspace` used by Haptic Desktop, so the desktop launcher and file browser can open real texts and audio without depending on external user content during first-run validation.
+
 The current loading strategy is intentionally segmented:
 
 - full source documents are preserved in the repository

--- a/docs/scope_and_motivation.md
+++ b/docs/scope_and_motivation.md
@@ -81,9 +81,18 @@ Purpose:
 
 Purpose:
 
-- represent digital actions as tactile objects
-- provide labeled interaction targets for folders, media, settings, and tools
-- support future audio-assisted but not audio-dependent desktop interaction
+- represent digital actions as tactile objects inside a changing 3D scene system
+- provide structured launch, gallery, file-browsing, and opened-content flows
+- support audio-assisted but not audio-dependent interaction for models, text, and audio
+- prepare the ground for a future autonomous haptic desktop experience
+
+### Supporting Route: Haptic Workspace Manager
+
+Purpose:
+
+- create and register structured `haptic_workspace` descriptors
+- keep large user assets outside the application repository
+- define curated galleries and a controlled file-browser root for blind-first desktop sessions
 
 ## Accessibility Position
 
@@ -117,6 +126,8 @@ The current baseline already delivers:
 - real 3D workspace rendering for object, Braille, and desktop modes
 - stylus-style pointer emulation for no-device execution
 - scene-native tactile controls inside the Braille reading world
+- structured `haptic_workspace` descriptors plus a dedicated manager route
+- workspace-driven Haptic Desktop scenes for launcher, galleries, file browsing, and content opening
 - bundled OBJ demo models and local OBJ staging
 - initial haptic material profiles grounded in current desktop-haptics capabilities
 - a null backend strategy for hardware-safe execution

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -89,19 +89,37 @@ Route:
 
 Current use:
 
-- move the stylus-style pointer proxy through a shape-coded desktop world
-- let the pointer focus desktop objects by spatial proximity
-- activate the focused object
-- inspect the current announcement and focus metadata
+- select the active structured workspace from the left panel
+- load the bundled demo workspace or a registered external workspace
+- start in a tactile launcher with entry objects for models, texts, audio, and the workspace file browser
+- move through paginated gallery scenes and a workspace-root file browser
+- open a detail plaque that exposes the content name before opening the real scene
+- open 3D model scenes, Braille reading scenes, and audio transport scenes with scene-native return controls
 
 Current keyboard cues:
 
-- `W`, `A`, `S`, `D`: move across the desktop world
-- `Q`, `E`: move vertically
-- `Space` or `Enter`: activate the focused desktop object
+- `W`, `A`, `S`, `D`: move across the current tactile scene
+- `Q`, `E`: move vertically inside the bounded workspace
+- `Space`: activate the tactile control or item under the pointer
 - arrow keys: fallback debug focus traversal
+- `Enter`: fallback activation of the current focused control
 
-This workspace currently acts as a focused interaction prototype for future haptic desktop behavior.
+The blind-first contract in this mode is that the primary controls live inside the 3D world itself. The surrounding web controls remain a debug and setup layer.
+
+### 4. Haptic Workspace Manager
+
+Route:
+
+```text
+/haptic-workspace-manager
+```
+
+Current use:
+
+- create a new `haptic_workspace` rooted in an external folder on the local machine
+- auto-populate model, text, and audio libraries from supported files already present in that root
+- register an existing `.haptic_workspace.json` descriptor file
+- review the current workspace catalog before opening a workspace inside Haptic Desktop
 
 ## Runtime Information
 
@@ -126,7 +144,7 @@ python -m playwright install chromium
 python scripts\browser_scene_smoke.py
 ```
 
-This validation opens all three routes, captures the 3D canvas in Chromium, and fails if the pages log runtime errors or if the rendered scene looks under-populated.
+This validation opens the three 3D routes, captures the scene canvas in Chromium, and fails if the pages log runtime errors, miss workspace bootstrap data, or if the rendered scene looks under-populated.
 
 ## API Endpoints
 
@@ -199,11 +217,54 @@ GET /api/library/documents/{slug}?offset=0&max_chars=1200
 GET /api/library/audio
 ```
 
+### Haptic Workspace Catalog
+
+```text
+GET /api/haptic-workspaces
+```
+
+### Haptic Workspace Detail
+
+```text
+GET /api/haptic-workspaces/{slug}
+```
+
+### Haptic Workspace Browser
+
+```text
+GET /api/haptic-workspaces/{slug}/browse?path=
+```
+
+### Haptic Workspace Text Payload
+
+```text
+GET /api/haptic-workspaces/{slug}/text-file?path=...&offset=0&max_chars=1200
+```
+
+### Haptic Workspace Raw File
+
+```text
+GET /api/haptic-workspaces/{slug}/raw-file?path=...
+```
+
+### Haptic Workspace Create
+
+```text
+POST /api/haptic-workspaces/create
+```
+
+### Haptic Workspace Register
+
+```text
+POST /api/haptic-workspaces/register
+```
+
 ## Current Limitations
 
 - no physical device bridge is connected yet
 - 3D object staging is currently client-side and focused on `.obj`
 - document compatibility is currently limited to bundled `txt`, `html`, and `epub` assets
-- bundled document selection still happens through the surrounding web controls rather than a scene-native library launcher
-- desktop actions are still frontend-level prototypes
+- bundled Braille library selection still begins from surrounding web controls rather than a scene-native library launcher
+- workspace authoring is currently JSON-descriptor based and still needs richer validation and editing affordances
+- desktop actions are limited to models, text, audio, and file browsing rather than full desktop automation
 - haptic material profiles are plausible approximations, not full physical simulation

--- a/installer/pyinstaller_version_info.txt
+++ b/installer/pyinstaller_version_info.txt
@@ -1,7 +1,7 @@
 VSVersionInfo(
   ffi=FixedFileInfo(
-    filevers=(0, 4, 0, 0),
-    prodvers=(0, 4, 0, 0),
+    filevers=(0, 5, 0, 0),
+    prodvers=(0, 5, 0, 0),
     mask=0x3F,
     flags=0x0,
     OS=0x40004,
@@ -16,11 +16,11 @@ VSVersionInfo(
         [
           StringStruct('CompanyName', 'Felipe Santibanez'),
           StringStruct('FileDescription', 'FeelIT'),
-          StringStruct('FileVersion', '0.4.0.0'),
+          StringStruct('FileVersion', '0.5.0.0'),
           StringStruct('InternalName', 'FeelIT'),
           StringStruct('OriginalFilename', 'FeelIT.exe'),
           StringStruct('ProductName', 'FeelIT'),
-          StringStruct('ProductVersion', '0.4.0')
+          StringStruct('ProductVersion', '0.5.0')
         ]
       )
     ]),

--- a/installer/version.iss
+++ b/installer/version.iss
@@ -1,4 +1,4 @@
 #define AppName "FeelIT"
-#define AppVersion "0.4.0"
+#define AppVersion "0.5.0"
 #define AppPublisher "Felipe Santibanez"
 #define AppExeName "FeelIT.exe"

--- a/scripts/browser_scene_smoke.py
+++ b/scripts/browser_scene_smoke.py
@@ -80,8 +80,32 @@ def run_browser_smoke(base_url: str, screenshot_dir: Path) -> None:
                 ),
             )
 
-            page.goto(f"{base_url}{scene.route}", wait_until="networkidle", timeout=30_000)
-            page.wait_for_timeout(2_200)
+            page.goto(f"{base_url}{scene.route}", wait_until="domcontentloaded", timeout=30_000)
+            page.wait_for_selector(scene.canvas_selector, state="visible", timeout=15_000)
+            if scene.route == "/braille-reader":
+                page.wait_for_function(
+                    """
+                    () => {
+                      const documents = document.querySelectorAll('#library-document-select option').length;
+                      const title = document.querySelector('#summary-document-title')?.textContent?.trim() ?? '';
+                      return documents > 0 && title !== '' && title !== 'Loading';
+                    }
+                    """,
+                    timeout=15_000,
+                )
+            if scene.route == "/haptic-desktop":
+                page.wait_for_function(
+                    """
+                    () => {
+                      const workspaces = document.querySelectorAll('#desktop-workspace-select option').length;
+                      const title = document.querySelector('#desktop-workspace-title')?.textContent?.trim() ?? '';
+                      const sceneCode = document.querySelector('#desktop-scene-code')?.textContent?.trim() ?? '';
+                      return workspaces > 0 && title !== '' && title !== 'Loading' && title !== 'No workspace' && sceneCode !== '' && sceneCode !== '--' && sceneCode !== 'Loading';
+                    }
+                    """,
+                    timeout=15_000,
+                )
+            page.wait_for_timeout(1_200)
 
             screenshot_path = screenshot_dir / f"{scene.route.strip('/').replace('-', '_')}.png"
             page.locator(scene.canvas_selector).screenshot(path=str(screenshot_path))
@@ -119,6 +143,16 @@ def run_browser_smoke(base_url: str, screenshot_dir: Path) -> None:
                     failures.append("/braille-reader did not populate the internal audio library selector")
                 if document_title in {"", "Loading"}:
                     failures.append("/braille-reader did not initialize the active library document summary")
+            if scene.route == "/haptic-desktop":
+                workspace_options = page.locator("#desktop-workspace-select option").count()
+                workspace_title = (page.locator("#desktop-workspace-title").text_content() or "").strip()
+                scene_code = (page.locator("#desktop-scene-code").text_content() or "").strip()
+                if workspace_options == 0:
+                    failures.append("/haptic-desktop did not populate the workspace selector")
+                if workspace_title in {"", "Loading", "No workspace"}:
+                    failures.append("/haptic-desktop did not initialize the active workspace summary")
+                if scene_code in {"", "--", "Loading"}:
+                    failures.append("/haptic-desktop did not initialize the scene code")
 
             print(
                 f"{scene.route}: unique_colors={unique_colors} "
@@ -153,7 +187,7 @@ def main() -> None:
     try:
         if not args.no_launch:
             server_process = subprocess.Popen(
-                [sys.executable, "run_app.py"],
+                [sys.executable, "run_app.py", "--no-browser"],
                 cwd=ROOT,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,12 +16,12 @@ def test_health_endpoint_reports_port_and_backend() -> None:
     assert payload["haptics"]["backend"] == "null"
 
 
-def test_modes_endpoint_exposes_three_modes() -> None:
+def test_modes_endpoint_exposes_four_modes() -> None:
     with TestClient(app) as client:
         response = client.get("/api/modes")
     assert response.status_code == 200
     payload = response.json()
-    assert len(payload["modes"]) == 3
+    assert len(payload["modes"]) == 4
 
 
 def test_meta_endpoint_reports_version_and_routes() -> None:
@@ -34,6 +34,7 @@ def test_meta_endpoint_reports_version_and_routes() -> None:
         "/object-explorer",
         "/braille-reader",
         "/haptic-desktop",
+        "/haptic-workspace-manager",
     }
 
 
@@ -49,6 +50,7 @@ def test_frontend_mode_routes_are_served() -> None:
         object_response = client.get("/object-explorer")
         braille_response = client.get("/braille-reader")
         desktop_response = client.get("/haptic-desktop")
+        manager_response = client.get("/haptic-workspace-manager")
     assert object_response.status_code == 200
     assert "3D Object Explorer" in object_response.text
     assert "Space activate" in object_response.text
@@ -64,10 +66,15 @@ def test_frontend_mode_routes_are_served() -> None:
     assert '/static/js/app.js" defer' not in braille_response.text
     assert desktop_response.status_code == 200
     assert "Haptic Desktop" in desktop_response.text
-    assert "Activate (Fallback)" in desktop_response.text
+    assert "Load Workspace" in desktop_response.text
+    assert "Virtual Desktop Workspace" in desktop_response.text
     assert "Space activate" in desktop_response.text
     assert 'type="module" src="/static/js/haptic_desktop.js"' in desktop_response.text
     assert '/static/js/app.js" defer' not in desktop_response.text
+    assert manager_response.status_code == 200
+    assert "Haptic Workspace Manager" in manager_response.text
+    assert "Create Workspace" in manager_response.text
+    assert 'type="module" src="/static/js/haptic_workspace_manager.js"' in manager_response.text
 
 
 def test_three_vendor_runtime_assets_are_served() -> None:

--- a/tests/test_haptic_workspace.py
+++ b/tests/test_haptic_workspace.py
@@ -1,0 +1,138 @@
+"""Tests for Haptic Desktop workspace descriptors and APIs."""
+
+from __future__ import annotations
+
+import json
+
+from fastapi.testclient import TestClient
+
+from app.core import haptic_workspace
+from app.main import app
+
+
+def test_demo_workspace_catalog_exposes_bundled_workspace() -> None:
+    catalog = haptic_workspace.build_haptic_workspace_catalog()
+    demo = next((workspace for workspace in catalog if workspace["slug"] == "feelit_demo_workspace"), None)
+    assert demo is not None
+    assert demo["is_default"] is True
+    assert demo["category_counts"]["models"] >= 3
+    assert demo["category_counts"]["texts"] >= 3
+    assert demo["category_counts"]["audio"] >= 2
+
+
+def test_demo_workspace_payload_resolves_bundled_libraries() -> None:
+    payload = haptic_workspace.build_haptic_workspace_payload("feelit_demo_workspace")
+    assert payload["title"] == "FeelIT Demo Workspace"
+    assert any(item["kind"] == "model" for item in payload["libraries"]["models"])
+    assert any(item["kind"] == "text" for item in payload["libraries"]["texts"])
+    assert any(item["kind"] == "audio" for item in payload["libraries"]["audio"])
+
+
+def test_demo_workspace_browser_payload_lists_internal_library_entries() -> None:
+    payload = haptic_workspace.build_workspace_browser_payload("feelit_demo_workspace")
+    entry_titles = {entry["title"] for entry in payload["entries"]}
+    assert payload["current_path"] == ""
+    assert "audio" in entry_titles
+    assert "documents" in entry_titles
+
+
+def test_create_workspace_file_auto_populates_supported_assets(tmp_path, monkeypatch) -> None:
+    registry_file = tmp_path / "registry.json"
+    monkeypatch.setattr(haptic_workspace, "REGISTRY_FILE", registry_file)
+
+    workspace_root = tmp_path / "workspace_root"
+    workspace_root.mkdir()
+    (workspace_root / "sample_model.obj").write_text("v 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n", encoding="utf-8")
+    (workspace_root / "sample_text.txt").write_text("Accessible tactile reading sample.", encoding="utf-8")
+    (workspace_root / "sample_audio.wav").write_bytes(b"RIFFdemoWAVEfmt ")
+
+    record = haptic_workspace.create_workspace_file(
+        title="My Workspace",
+        slug="my_workspace",
+        description="Temporary workspace for automated tests.",
+        root_path=str(workspace_root),
+        auto_populate=True,
+    )
+
+    descriptor_path = workspace_root / "my_workspace.haptic_workspace.json"
+    assert descriptor_path.exists()
+    assert record["slug"] == "my_workspace"
+
+    payload = haptic_workspace.build_haptic_workspace_payload("my_workspace")
+    assert any(item["kind"] == "model" for item in payload["libraries"]["models"])
+    assert any(item["kind"] == "text" for item in payload["libraries"]["texts"])
+    assert any(item["kind"] == "audio" for item in payload["libraries"]["audio"])
+
+
+def test_haptic_workspace_create_and_register_endpoints_use_external_registry(tmp_path, monkeypatch) -> None:
+    registry_file = tmp_path / "registry.json"
+    monkeypatch.setattr(haptic_workspace, "REGISTRY_FILE", registry_file)
+
+    created_root = tmp_path / "created_workspace"
+    created_root.mkdir()
+    (created_root / "scene.obj").write_text("v 0 0 0\nv 0 1 0\nv 1 0 0\nf 1 2 3\n", encoding="utf-8")
+    (created_root / "notes.txt").write_text("Braille library note.", encoding="utf-8")
+
+    existing_root = tmp_path / "existing_workspace"
+    existing_root.mkdir()
+    descriptor_path = existing_root / "registered_workspace.haptic_workspace.json"
+    descriptor_path.write_text(
+        json.dumps(
+            {
+                "format": haptic_workspace.WORKSPACE_FORMAT,
+                "format_version": 1,
+                "slug": "registered_workspace",
+                "title": "Registered Workspace",
+                "description": "Existing descriptor file for API registration.",
+                "is_default": False,
+                "content_root": {"mode": "absolute", "path": str(existing_root)},
+                "file_browser_root": {"mode": "absolute", "path": str(existing_root)},
+                "libraries": {"models": [], "texts": [], "audio": []},
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    with TestClient(app) as client:
+        create_response = client.post(
+            "/api/haptic-workspaces/create",
+            json={
+                "title": "Created Workspace",
+                "slug": "created_workspace",
+                "description": "Workspace created from an external root.",
+                "root_path": str(created_root),
+                "auto_populate": True,
+            },
+        )
+        register_response = client.post(
+            "/api/haptic-workspaces/register",
+            json={"workspace_file_path": str(descriptor_path)},
+        )
+        catalog_response = client.get("/api/haptic-workspaces")
+
+    assert create_response.status_code == 200
+    assert create_response.json()["workspace"]["slug"] == "created_workspace"
+    assert register_response.status_code == 200
+    assert register_response.json()["workspace"]["slug"] == "registered_workspace"
+    assert catalog_response.status_code == 200
+    payload = catalog_response.json()
+    assert any(workspace["slug"] == "created_workspace" for workspace in payload["workspaces"])
+    assert any(workspace["slug"] == "registered_workspace" for workspace in payload["workspaces"])
+
+
+def test_haptic_workspace_api_returns_demo_workspace_payload_browse_and_text() -> None:
+    with TestClient(app) as client:
+        detail_response = client.get("/api/haptic-workspaces/feelit_demo_workspace")
+        browse_response = client.get("/api/haptic-workspaces/feelit_demo_workspace/browse")
+        text_response = client.get(
+            "/api/haptic-workspaces/feelit_demo_workspace/text-file",
+            params={"path": "documents/alice_in_wonderland.txt", "offset": 0, "max_chars": 400},
+        )
+
+    assert detail_response.status_code == 200
+    assert browse_response.status_code == 200
+    assert text_response.status_code == 200
+    assert detail_response.json()["slug"] == "feelit_demo_workspace"
+    assert any(entry["title"] == "documents" for entry in browse_response.json()["entries"])
+    assert "Alice" in text_response.json()["text"]


### PR DESCRIPTION
## Summary
- add the `haptic_workspace` descriptor format, bundled demo workspace, and local registry services
- add the Haptic Workspace Manager route for creating and registering external-root workspaces
- rebuild Haptic Desktop around launcher, gallery, file-browser, detail, and opened-content scenes
- add workspace-domain/API tests and strengthen the browser smoke validator for desktop bootstrap
- bump FeelIT to 0.5.0 and synchronize documentation and packaging metadata

Closes #19
Closes #20
Closes #21
Closes #22

Progresses #9
Refs #18
