### PR TITLE
Fix: expand Haptic Desktop demo gallery coverage and pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The current implementation provides real 3D workspace rendering across the spati
 
 ## Current Version
 
-`0.5.0`
+`0.5.1`
 
 ## Public Port
 
@@ -42,7 +42,7 @@ Operational workspace that translates text into Braille cells, lays them out on 
 
 ### Haptic Desktop
 
-Workspace-driven tactile desktop that now transitions through a launcher, curated galleries, a file browser, item detail plaques, and opened scenes for models, text, and audio.
+Workspace-driven tactile desktop that now transitions through a launcher, paginated galleries, a file browser, item detail plaques, and opened scenes for models, text, and audio. The bundled demo workspace mirrors the full internal demo library so the gallery flow covers every bundled model, document, and audio sample.
 
 ### Haptic Workspace Manager
 
@@ -96,7 +96,7 @@ FeelIT now includes a structured workspace layer for Haptic Desktop:
   - `POST /api/haptic-workspaces/create`
   - `POST /api/haptic-workspaces/register`
 
-The demo desktop workspace uses curated galleries plus a file-browser root. User-created workspaces keep their heavy assets outside the repository and only register descriptor files locally.
+The demo desktop workspace uses curated galleries plus a file-browser root, and it auto-surfaces the full bundled asset catalog so no internal demo item is omitted from the launcher flow. User-created workspaces keep their heavy assets outside the repository and only register descriptor files locally.
 
 ## Quick Start
 
@@ -153,6 +153,7 @@ python scripts\browser_scene_smoke.py
 - Braille preview API at `POST /api/braille/preview`
 - bounded 3D Braille world with scene-native page controls plus auxiliary inspection board
 - workspace-driven 3D desktop launcher, galleries, file browser, detail scenes, and opened content scenes
+- bundled demo-workspace galleries synchronized against the full internal model, text, and audio catalogs
 - null haptic backend abstraction for no-device execution
 - shared runtime metadata for version, port, and device state
 

--- a/app/core/haptic_workspace.py
+++ b/app/core/haptic_workspace.py
@@ -129,6 +129,70 @@ def _read_workspace_descriptor(path: Path) -> dict[str, Any]:
     return descriptor
 
 
+def _bundled_demo_workspace_defaults() -> dict[str, list[dict[str, Any]]]:
+    """Return the complete seeded library for the bundled demo workspace."""
+    return {
+        "models": [
+            {
+                "slug": f"{model['slug']}_session",
+                "title": model["title"],
+                "summary": model["description"],
+                "source": {"kind": "demo_model", "ref": model["slug"]},
+            }
+            for model in build_demo_model_catalog()
+        ],
+        "texts": [
+            {
+                "slug": f"{document['slug']}_session",
+                "title": document["title"],
+                "summary": document["summary"],
+                "source": {"kind": "library_document", "ref": document["slug"]},
+            }
+            for document in build_document_catalog()
+        ],
+        "audio": [
+            {
+                "slug": f"{audio['slug']}_session",
+                "title": audio["title"],
+                "summary": audio["summary"],
+                "source": {"kind": "library_audio", "ref": audio["slug"]},
+            }
+            for audio in build_audio_catalog()
+        ],
+    }
+
+
+def _normalize_workspace_libraries(
+    descriptor: dict[str, Any],
+    *,
+    registry_source: str,
+) -> dict[str, list[dict[str, Any]]]:
+    """Return workspace libraries with any bundled-demo defaults merged in."""
+    libraries = {
+        category: [dict(item) for item in descriptor.get("libraries", {}).get(category, [])]
+        for category in ("models", "texts", "audio")
+    }
+
+    if not (
+        registry_source == "bundled_demo"
+        and descriptor.get("auto_include_all_bundled_assets")
+    ):
+        return libraries
+
+    defaults = _bundled_demo_workspace_defaults()
+    for category in ("models", "texts", "audio"):
+        existing_refs = {
+            item.get("source", {}).get("ref")
+            for item in libraries[category]
+            if item.get("source", {}).get("kind")
+        }
+        for item in defaults[category]:
+            ref = item["source"]["ref"]
+            if ref not in existing_refs:
+                libraries[category].append(item)
+    return libraries
+
+
 def _load_workspace_record(path: Path, *, registry_source: str) -> dict[str, Any]:
     """Return a resolved catalog record for one workspace descriptor file."""
     descriptor = _read_workspace_descriptor(path)
@@ -139,7 +203,7 @@ def _load_workspace_record(path: Path, *, registry_source: str) -> dict[str, Any
     if not file_browser_root.exists():
         raise ValueError(f"Workspace file-browser root does not exist for {path.name}.")
 
-    libraries = descriptor.get("libraries", {})
+    libraries = _normalize_workspace_libraries(descriptor, registry_source=registry_source)
     return {
         "slug": descriptor["slug"],
         "title": descriptor["title"],

--- a/app/core/version.py
+++ b/app/core/version.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 APP_NAME = "FeelIT"
-APP_VERSION = "0.5.0"
+APP_VERSION = "0.5.1"
 APP_PUBLISHER = "Felipe Santibanez"
 
 

--- a/app/static/assets/workspaces/feelit_demo.haptic_workspace.json
+++ b/app/static/assets/workspaces/feelit_demo.haptic_workspace.json
@@ -5,6 +5,7 @@
   "title": "FeelIT Demo Workspace",
   "description": "Curated launcher workspace that combines demo models, bundled documents, bundled audio, and a controlled file-browser root for internal demonstrations.",
   "is_default": true,
+  "auto_include_all_bundled_assets": true,
   "content_root": {
     "mode": "app_static_relative",
     "path": "assets"

--- a/app/static/js/haptic_desktop.js
+++ b/app/static/js/haptic_desktop.js
@@ -17,7 +17,7 @@ const workspaceRawUrl = (slug, path) =>
   `/api/haptic-workspaces/${encodeURIComponent(slug)}/raw-file?path=${encodeURIComponent(path)}`;
 const braillePreviewUrl = "/api/braille/preview";
 
-const GALLERY_PAGE_SIZE = 6;
+const GALLERY_PAGE_SIZE = 3;
 const FILE_BROWSER_PAGE_SIZE = 6;
 const TEXT_COLUMNS = 8;
 const TEXT_ROWS_PER_PAGE = 4;
@@ -375,6 +375,38 @@ function addFloatingLabel(group, text, y = 0.72, color = "#8b949e") {
   });
   sprite.position.set(0, y, 0);
   group.add(sprite);
+}
+
+function truncateLabelLine(text, maxLength = 84) {
+  return text.length > maxLength ? `${text.slice(0, maxLength - 1)}…` : text;
+}
+
+function addGallerySummary(category, pageSlice, totalCount) {
+  if (pageSlice.items.length === 0) {
+    return;
+  }
+  const firstItem = pageSlice.page * GALLERY_PAGE_SIZE + 1;
+  const lastItem = firstItem + pageSlice.items.length - 1;
+  const rangeLine = `${CATEGORY_META[category].title} • page ${pageSlice.page + 1} of ${pageSlice.pageCount} • items ${firstItem}-${lastItem} of ${totalCount}`;
+  const titlesLine = truncateLabelLine(
+    `Visible now: ${pageSlice.items.map((item) => item.title).join(" | ")}`,
+  );
+
+  const rangeSprite = createLabelSprite(rangeLine, {
+    background: "rgba(13, 17, 23, 0.76)",
+    color: "#e6edf3",
+    fontSize: 14,
+  });
+  rangeSprite.position.set(0, 0.64, -1.5);
+  state.sceneApi.world.add(rangeSprite);
+
+  const titlesSprite = createLabelSprite(titlesLine, {
+    background: "rgba(13, 17, 23, 0.68)",
+    color: "#8b949e",
+    fontSize: 13,
+  });
+  titlesSprite.position.set(0, 0.46, -1.5);
+  state.sceneApi.world.add(titlesSprite);
 }
 
 function beginSceneBuild(title) {
@@ -1036,13 +1068,19 @@ function buildBraillePlaque(cells, columns, options = {}) {
 }
 
 function galleryTilePositions(count) {
+  if (count <= 1) {
+    return [new THREE.Vector3(0, 0.12, 0.02)].slice(0, count);
+  }
+  if (count === 2) {
+    return [
+      new THREE.Vector3(-1.18, 0.12, 0.02),
+      new THREE.Vector3(1.18, 0.12, 0.02),
+    ];
+  }
   return [
-    new THREE.Vector3(-1.55, 0.12, -0.72),
-    new THREE.Vector3(0, 0.12, -0.72),
-    new THREE.Vector3(1.55, 0.12, -0.72),
-    new THREE.Vector3(-1.55, 0.12, 0.82),
-    new THREE.Vector3(0, 0.12, 0.82),
-    new THREE.Vector3(1.55, 0.12, 0.82),
+    new THREE.Vector3(-1.48, 0.12, -0.26),
+    new THREE.Vector3(0, 0.12, 0.56),
+    new THREE.Vector3(1.48, 0.12, -0.26),
   ].slice(0, count);
 }
 
@@ -1259,12 +1297,12 @@ async function navigateToGallery(category, page = 0) {
   const workspace = state.activeWorkspace;
   const pageSlice = slicePage(workspace.libraries[category], GALLERY_PAGE_SIZE, page);
   prepareScene(
-    5.8,
-    4.5,
+    5.4,
+    4.6,
     CATEGORY_META[category].title,
     `Scene 2: paginated tactile gallery for ${category}.`,
-    [5.2, 3.4, 5.4],
-    [0, 0.28, 0.16],
+    [0, 3.65, 5.15],
+    [0, 0.3, 0.08],
   );
 
   const positions = galleryTilePositions(pageSlice.items.length);
@@ -1273,6 +1311,7 @@ async function navigateToGallery(category, page = 0) {
       navigateToDetail(item, { type: "gallery", category, page: pageSlice.page }),
     );
   });
+  addGallerySummary(category, pageSlice, workspace.libraries[category].length);
 
   addControlTarget({
     id: `gallery-${category}-home`,

--- a/docs/development_history.md
+++ b/docs/development_history.md
@@ -15,6 +15,22 @@ The archived user manual describes the software as a digital-to-relief presentat
 
 ## Modern Rebuild Timeline
 
+### v0.5.1 (2026-03-29)
+
+Patch release focused on full bundled gallery coverage in the demo workspace, clearer Haptic Desktop pagination, and isolated browser smoke validation.
+
+Delivered:
+
+- Merged the bundled demo workspace with the full internal model, text, and audio catalogs so every bundled asset appears in Haptic Desktop galleries.
+- Reduced gallery density per page and reworked gallery framing so multiple tactile items are clearly staged in the 3D scene at once.
+- Hardened the browser smoke test to launch FeelIT on an isolated temporary port and verify real gallery pagination.
+
+Rationale:
+
+- Keep the default demo workspace aligned with the actual internal library instead of drifting into a partial subset.
+- Make the gallery scene visually and operationally communicate that users are moving through a real paginated collection, not a single-item showcase.
+- Prevent false regression results caused by stale local servers already occupying the default application port.
+
 ### v0.5.0 (2026-03-29)
 
 Release focused on workspace-driven Haptic Desktop scenes, structured haptic_workspace descriptors, and the first external-workspace management flow.

--- a/docs/implementation_gap_audit.md
+++ b/docs/implementation_gap_audit.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document separates what FeelIT `0.5.0` demonstrably implements today from what remains partial, planned, or hardware-dependent.
+This document separates what FeelIT `0.5.1` demonstrably implements today from what remains partial, planned, or hardware-dependent.
 
 It is intentionally conservative. If a behavior is not visible in the runtime, testable through the current repo, or clearly encoded in the shipped code path, it is not treated here as delivered.
 
@@ -83,6 +83,7 @@ Implemented:
 - dedicated workspace-manager route for creating and registering workspaces rooted in external folders
 - launcher scene for curated models, texts, audio, and workspace file browsing
 - paginated gallery scenes backed by workspace payloads
+- bundled demo-workspace galleries synchronized against the full internal model, text, and audio catalogs
 - file-browser scene rooted in the configured workspace path
 - detail plaque scene that exposes the content name before opening it
 - opened scenes for 3D models, Braille reading, and audio transport

--- a/docs/library_catalog.md
+++ b/docs/library_catalog.md
@@ -8,7 +8,7 @@ This document summarizes the internal public-domain library currently bundled wi
 
 The internal library exists to make the Braille Reader immediately demonstrable without relying on ad hoc pasted text or remote network access during a session.
 
-The same internal assets now also seed the bundled demo `haptic_workspace` used by Haptic Desktop, so the desktop launcher and file browser can open real texts and audio without depending on external user content during first-run validation.
+The same internal assets now also seed the bundled demo `haptic_workspace` used by Haptic Desktop, and the demo workspace mirrors the full bundled catalog instead of a partial subset. This keeps the desktop launcher and paginated galleries aligned with the real internal library during first-run validation.
 
 The current loading strategy is intentionally segmented:
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -91,8 +91,9 @@ Current use:
 
 - select the active structured workspace from the left panel
 - load the bundled demo workspace or a registered external workspace
+- use the bundled demo workspace as a full internal-library baseline covering every bundled model, document, and audio sample
 - start in a tactile launcher with entry objects for models, texts, audio, and the workspace file browser
-- move through paginated gallery scenes and a workspace-root file browser
+- move through smaller paginated gallery scenes and a workspace-root file browser
 - open a detail plaque that exposes the content name before opening the real scene
 - open 3D model scenes, Braille reading scenes, and audio transport scenes with scene-native return controls
 

--- a/installer/pyinstaller_version_info.txt
+++ b/installer/pyinstaller_version_info.txt
@@ -1,7 +1,7 @@
 VSVersionInfo(
   ffi=FixedFileInfo(
-    filevers=(0, 5, 0, 0),
-    prodvers=(0, 5, 0, 0),
+    filevers=(0, 5, 1, 0),
+    prodvers=(0, 5, 1, 0),
     mask=0x3F,
     flags=0x0,
     OS=0x40004,
@@ -16,11 +16,11 @@ VSVersionInfo(
         [
           StringStruct('CompanyName', 'Felipe Santibanez'),
           StringStruct('FileDescription', 'FeelIT'),
-          StringStruct('FileVersion', '0.5.0.0'),
+          StringStruct('FileVersion', '0.5.1.0'),
           StringStruct('InternalName', 'FeelIT'),
           StringStruct('OriginalFilename', 'FeelIT.exe'),
           StringStruct('ProductName', 'FeelIT'),
-          StringStruct('ProductVersion', '0.5.0')
+          StringStruct('ProductVersion', '0.5.1')
         ]
       )
     ]),

--- a/installer/version.iss
+++ b/installer/version.iss
@@ -1,4 +1,4 @@
 #define AppName "FeelIT"
-#define AppVersion "0.5.0"
+#define AppVersion "0.5.1"
 #define AppPublisher "Felipe Santibanez"
 #define AppExeName "FeelIT.exe"

--- a/scripts/browser_scene_smoke.py
+++ b/scripts/browser_scene_smoke.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import argparse
+import socket
 import subprocess
 import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import urlparse
 
 from PIL import Image
 from playwright.sync_api import sync_playwright
@@ -29,6 +31,13 @@ SCENES: tuple[SceneSpec, ...] = (
     SceneSpec(route="/braille-reader", canvas_selector="#braille-canvas", min_unique_colors=1500),
     SceneSpec(route="/haptic-desktop", canvas_selector="#desktop-canvas", min_unique_colors=1500),
 )
+
+
+def reserve_free_local_port() -> int:
+    """Return an available localhost TCP port for temporary test launches."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
 
 
 def wait_for_server(process: subprocess.Popen[str], timeout_seconds: int) -> None:
@@ -105,6 +114,17 @@ def run_browser_smoke(base_url: str, screenshot_dir: Path) -> None:
                     """,
                     timeout=15_000,
                 )
+                page.locator("#focus-activate").click()
+                page.wait_for_function(
+                    """
+                    () => {
+                      const sceneCode = document.querySelector('#desktop-scene-code')?.textContent?.trim() ?? '';
+                      const pagination = document.querySelector('#desktop-pagination')?.textContent?.trim() ?? '';
+                      return sceneCode === 'models-gallery' && pagination !== '' && pagination !== '--';
+                    }
+                    """,
+                    timeout=15_000,
+                )
             page.wait_for_timeout(1_200)
 
             screenshot_path = screenshot_dir / f"{scene.route.strip('/').replace('-', '_')}.png"
@@ -147,10 +167,15 @@ def run_browser_smoke(base_url: str, screenshot_dir: Path) -> None:
                 workspace_options = page.locator("#desktop-workspace-select option").count()
                 workspace_title = (page.locator("#desktop-workspace-title").text_content() or "").strip()
                 scene_code = (page.locator("#desktop-scene-code").text_content() or "").strip()
+                pagination = (page.locator("#desktop-pagination").text_content() or "").strip()
                 if workspace_options == 0:
                     failures.append("/haptic-desktop did not populate the workspace selector")
                 if workspace_title in {"", "Loading", "No workspace"}:
                     failures.append("/haptic-desktop did not initialize the active workspace summary")
+                if scene_code != "models-gallery":
+                    failures.append("/haptic-desktop did not navigate from launcher into the models gallery")
+                if pagination in {"", "--", "1 / 1"}:
+                    failures.append("/haptic-desktop models gallery did not expose real pagination")
                 if scene_code in {"", "--", "Loading"}:
                     failures.append("/haptic-desktop did not initialize the scene code")
 
@@ -184,10 +209,15 @@ def main() -> None:
     args = parser.parse_args()
 
     server_process: subprocess.Popen[str] | None = None
+    base_url = args.base_url
     try:
         if not args.no_launch:
+            parsed = urlparse(args.base_url)
+            host = parsed.hostname or "127.0.0.1"
+            port = reserve_free_local_port()
+            base_url = f"http://{host}:{port}"
             server_process = subprocess.Popen(
-                [sys.executable, "run_app.py", "--no-browser"],
+                [sys.executable, "run_app.py", "--no-browser", "--host", host, "--port", str(port)],
                 cwd=ROOT,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
@@ -195,7 +225,7 @@ def main() -> None:
             )
             wait_for_server(server_process, timeout_seconds=30)
 
-        run_browser_smoke(args.base_url, Path(args.screenshot_dir))
+        run_browser_smoke(base_url, Path(args.screenshot_dir))
         print("Browser smoke test passed.")
     finally:
         if server_process is not None:

--- a/tests/test_haptic_workspace.py
+++ b/tests/test_haptic_workspace.py
@@ -6,7 +6,9 @@ import json
 
 from fastapi.testclient import TestClient
 
+from app.core.demo_assets import build_demo_model_catalog
 from app.core import haptic_workspace
+from app.core.library_assets import build_audio_catalog, build_document_catalog
 from app.main import app
 
 
@@ -15,9 +17,9 @@ def test_demo_workspace_catalog_exposes_bundled_workspace() -> None:
     demo = next((workspace for workspace in catalog if workspace["slug"] == "feelit_demo_workspace"), None)
     assert demo is not None
     assert demo["is_default"] is True
-    assert demo["category_counts"]["models"] >= 3
-    assert demo["category_counts"]["texts"] >= 3
-    assert demo["category_counts"]["audio"] >= 2
+    assert demo["category_counts"]["models"] == len(build_demo_model_catalog())
+    assert demo["category_counts"]["texts"] == len(build_document_catalog())
+    assert demo["category_counts"]["audio"] == len(build_audio_catalog())
 
 
 def test_demo_workspace_payload_resolves_bundled_libraries() -> None:
@@ -26,6 +28,20 @@ def test_demo_workspace_payload_resolves_bundled_libraries() -> None:
     assert any(item["kind"] == "model" for item in payload["libraries"]["models"])
     assert any(item["kind"] == "text" for item in payload["libraries"]["texts"])
     assert any(item["kind"] == "audio" for item in payload["libraries"]["audio"])
+
+
+def test_demo_workspace_payload_covers_all_bundled_assets() -> None:
+    payload = haptic_workspace.build_haptic_workspace_payload("feelit_demo_workspace")
+
+    assert {item["source"]["ref"] for item in payload["libraries"]["models"]} == {
+        item["slug"] for item in build_demo_model_catalog()
+    }
+    assert {item["source"]["ref"] for item in payload["libraries"]["texts"]} == {
+        item["slug"] for item in build_document_catalog()
+    }
+    assert {item["source"]["ref"] for item in payload["libraries"]["audio"]} == {
+        item["slug"] for item in build_audio_catalog()
+    }
 
 
 def test_demo_workspace_browser_payload_lists_internal_library_entries() -> None:


### PR DESCRIPTION
## Summary
- merge the bundled demo workspace with the full internal model, text, and audio catalogs
- reframe Haptic Desktop gallery pages so the paginated 3D scene shows fewer, clearer items per page
- harden browser smoke validation by launching FeelIT on an isolated temporary port and asserting real gallery pagination

## Validation
- python -m pytest tests -v
- python -m compileall app tests run_app.py scripts
- python scripts\\browser_scene_smoke.py

Fixes #24