### PR TITLE
Fix: stabilize Haptic Desktop launcher return flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The current implementation provides real 3D workspace rendering across the spati
 
 ## Current Version
 
-`0.5.2`
+`0.5.3`
 
 ## Public Port
 

--- a/app/core/version.py
+++ b/app/core/version.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 APP_NAME = "FeelIT"
-APP_VERSION = "0.5.2"
+APP_VERSION = "0.5.3"
 APP_PUBLISHER = "Felipe Santibanez"
 
 

--- a/app/static/haptic_desktop.html
+++ b/app/static/haptic_desktop.html
@@ -191,6 +191,7 @@
           <li>Select the active workspace from the left panel, then load it into the scene engine.</li>
           <li>Move the pointer emulator with `W`, `A`, `S`, `D`, `Q`, and `E` and activate focused objects with `Space` or `Enter`.</li>
           <li>Use tactile scene controls for the launcher, gallery start or file-browser root, back navigation, paging, opening content, and browsing the workspace file root.</li>
+          <li>Returning to the launcher should land on the neutral launcher hub first, not on a specific gallery tile.</li>
           <li>Use spoken cues as a support channel while keeping the object shapes and scene changes as the primary interaction contract.</li>
         </ul>
         <h3>Current Limits</h3>

--- a/app/static/js/haptic_desktop.js
+++ b/app/static/js/haptic_desktop.js
@@ -1264,6 +1264,23 @@ async function navigateToLauncher() {
     "Scene 1: tactile launcher with direct access to curated galleries and file browsing.",
   );
 
+  addControlTarget({
+    id: "launcher-hub",
+    label: "Launcher",
+    type: "Launcher",
+    actionLabel: "Stay at the main launcher and survey the available entry points",
+    kind: "home",
+    color: 0x39d2c0,
+    position: new THREE.Vector3(0, 0.12, 0.12),
+    onActivate: async () => {
+      publishStatus(
+        `Main launcher. Models ${workspace.libraries.models.length}, texts ${workspace.libraries.texts.length}, audio ${workspace.libraries.audio.length}, plus workspace file browsing.`,
+        "Ready",
+        "launcher-hub",
+      );
+    },
+  });
+
   [
     {
       id: "launcher-models",
@@ -1335,7 +1352,7 @@ async function navigateToLauncher() {
     new THREE.Vector3(-2.2, 0.14, -1.6),
     new THREE.Vector3(2.2, 1.1, 1.8),
   );
-  state.pointerController.setPosition(new THREE.Vector3(-1.25, 0.36, -0.4));
+  state.pointerController.setPosition(new THREE.Vector3(0, 0.36, 0.18));
   assertSceneToken(token);
   finishSceneBuild({
     code: "launcher",
@@ -1346,7 +1363,7 @@ async function navigateToLauncher() {
     pagination: "1 / 1",
     idleMessage: "Pointer moving across the launcher scene.",
   });
-  focusTarget("launcher-models", { source: "scene", movePointer: false });
+  focusTarget("launcher-hub", { source: "scene", movePointer: false });
 }
 
 async function navigateToGallery(category, page = 0) {
@@ -1785,7 +1802,7 @@ async function navigateToModelScene(item, origin) {
   finishSceneBuild({
     code: "open-model",
     title: "3D Model Scene",
-    subtitle: "The opened object shares space with tactile home and gallery-return controls.",
+    subtitle: "The opened object shares space with tactile launcher, origin-start, and back-return controls.",
     context: detailOriginLabel(origin),
     path: item.source?.relative_path ?? item.source?.demo_model_slug ?? item.slug,
     pagination: "1 / 1",

--- a/app/static/js/three_scene_common.js
+++ b/app/static/js/three_scene_common.js
@@ -383,6 +383,7 @@ export function attachPointerEmulation(sceneApi, options = {}) {
       return;
     }
 
+    const wasAlreadyDown = keysDown.has(event.code);
     if (
       Object.values(keyMap).includes(event.code)
       || activationKeys.has(event.code)
@@ -391,7 +392,7 @@ export function attachPointerEmulation(sceneApi, options = {}) {
       event.preventDefault();
     }
     keysDown.add(event.code);
-    if (activationKeys.has(event.code) || activationKeys.has(event.key)) {
+    if (!wasAlreadyDown && (activationKeys.has(event.code) || activationKeys.has(event.key))) {
       const now = performance.now();
       if (now - lastActivation > 120) {
         activate();

--- a/docs/development_history.md
+++ b/docs/development_history.md
@@ -15,6 +15,21 @@ The archived user manual describes the software as a digital-to-relief presentat
 
 ## Modern Rebuild Timeline
 
+### v0.5.3 (2026-03-29)
+
+Patch release focused on deterministic launcher return semantics in Haptic Desktop and regression coverage for held activation across scene transitions.
+
+Delivered:
+
+- Made Launcher returns land on a neutral launcher hub instead of inheriting focus on a specific gallery tile.
+- Suppressed repeated held-key activations during scene transitions in the shared pointer emulator.
+- Extended the browser smoke validator to reproduce and guard the file-browser-to-launcher return path.
+
+Rationale:
+
+- Keep Haptic Desktop navigation semantically stable so blind-first return controls always land in the expected scene and focus anchor.
+- Prevent held activation from leaking across scene rebuilds and causing accidental follow-up navigation.
+
 ### v0.5.2 (2026-03-29)
 
 Patch release focused on explicit launcher and start or root return controls across Haptic Desktop scenes.

--- a/docs/implementation_gap_audit.md
+++ b/docs/implementation_gap_audit.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document separates what FeelIT `0.5.2` demonstrably implements today from what remains partial, planned, or hardware-dependent.
+This document separates what FeelIT `0.5.3` demonstrably implements today from what remains partial, planned, or hardware-dependent.
 
 It is intentionally conservative. If a behavior is not visible in the runtime, testable through the current repo, or clearly encoded in the shipped code path, it is not treated here as delivered.
 
@@ -81,7 +81,7 @@ Implemented:
 
 - structured `haptic_workspace` descriptor format with bundled demo workspace
 - dedicated workspace-manager route for creating and registering workspaces rooted in external folders
-- launcher scene for curated models, texts, audio, and workspace file browsing
+- launcher scene with a neutral launcher hub plus curated entry points for models, texts, audio, and workspace file browsing
 - paginated gallery scenes backed by workspace payloads
 - bundled demo-workspace galleries synchronized against the full internal model, text, and audio catalogs
 - explicit in-scene Launcher plus Start or Root return controls across gallery, browser, detail, and opened-content scenes

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -92,9 +92,10 @@ Current use:
 - select the active structured workspace from the left panel
 - load the bundled demo workspace or a registered external workspace
 - use the bundled demo workspace as a full internal-library baseline covering every bundled model, document, and audio sample
-- start in a tactile launcher with entry objects for models, texts, audio, and the workspace file browser
+- start in a tactile launcher with a neutral launcher hub plus entry objects for models, texts, audio, and the workspace file browser
 - move through smaller paginated gallery scenes and a workspace-root file browser
 - use explicit in-scene `Launcher` controls plus `Start` or `Root` controls to jump back to the main menu or the beginning of the active gallery or browser flow
+- expect `Launcher` to return to the neutral launcher hub, while `Back` returns to the previous scene and `Start` or `Root` return to the beginning of the active gallery or browser flow
 - open a detail plaque that exposes the content name before opening the real scene
 - open 3D model scenes, Braille reading scenes, and audio transport scenes with scene-native return controls
 

--- a/installer/pyinstaller_version_info.txt
+++ b/installer/pyinstaller_version_info.txt
@@ -1,7 +1,7 @@
 VSVersionInfo(
   ffi=FixedFileInfo(
-    filevers=(0, 5, 2, 0),
-    prodvers=(0, 5, 2, 0),
+    filevers=(0, 5, 3, 0),
+    prodvers=(0, 5, 3, 0),
     mask=0x3F,
     flags=0x0,
     OS=0x40004,
@@ -16,11 +16,11 @@ VSVersionInfo(
         [
           StringStruct('CompanyName', 'Felipe Santibanez'),
           StringStruct('FileDescription', 'FeelIT'),
-          StringStruct('FileVersion', '0.5.2.0'),
+          StringStruct('FileVersion', '0.5.3.0'),
           StringStruct('InternalName', 'FeelIT'),
           StringStruct('OriginalFilename', 'FeelIT.exe'),
           StringStruct('ProductName', 'FeelIT'),
-          StringStruct('ProductVersion', '0.5.2')
+          StringStruct('ProductVersion', '0.5.3')
         ]
       )
     ]),

--- a/installer/version.iss
+++ b/installer/version.iss
@@ -1,4 +1,4 @@
 #define AppName "FeelIT"
-#define AppVersion "0.5.2"
+#define AppVersion "0.5.3"
 #define AppPublisher "Felipe Santibanez"
 #define AppExeName "FeelIT.exe"

--- a/scripts/browser_scene_smoke.py
+++ b/scripts/browser_scene_smoke.py
@@ -129,7 +129,10 @@ def run_browser_smoke(base_url: str, screenshot_dir: Path) -> None:
                     """,
                     timeout=15_000,
                 )
-                page.locator("#focus-activate").click()
+                if not cycle_focus_to(page, "Models Gallery"):
+                    failures.append("/haptic-desktop could not focus Models Gallery from the launcher")
+                else:
+                    page.locator("#focus-activate").click()
                 page.wait_for_function(
                     """
                     () => {
@@ -179,7 +182,45 @@ def run_browser_smoke(base_url: str, screenshot_dir: Path) -> None:
                         """,
                         timeout=15_000,
                     )
-                    page.locator("#focus-activate").click()
+                    launcher_focus = focused_label(page)
+                    if launcher_focus != "Launcher":
+                        failures.append(
+                            f"/haptic-desktop returned to launcher but left focus on {launcher_focus!r} instead of 'Launcher'",
+                        )
+                    if not cycle_focus_to(page, "File Browser"):
+                        failures.append("/haptic-desktop could not focus File Browser from the launcher")
+                    else:
+                        page.locator("#focus-activate").click()
+                        page.wait_for_function(
+                            """
+                            () => {
+                              const sceneCode = document.querySelector('#desktop-scene-code')?.textContent?.trim() ?? '';
+                              return sceneCode === 'file-browser';
+                            }
+                            """,
+                            timeout=15_000,
+                        )
+                    if not cycle_focus_to(page, "Launcher"):
+                        failures.append("/haptic-desktop could not focus the file-browser Launcher control")
+                    else:
+                        page.keyboard.down("Space")
+                        page.wait_for_timeout(900)
+                        page.keyboard.up("Space")
+                        page.wait_for_timeout(700)
+                        scene_after_hold = (page.locator("#desktop-scene-code").text_content() or "").strip()
+                        focus_after_hold = focused_label(page)
+                        if scene_after_hold != "launcher":
+                            failures.append(
+                                f"/haptic-desktop held-space return from file browser ended on {scene_after_hold!r} instead of 'launcher'",
+                            )
+                        if focus_after_hold != "Launcher":
+                            failures.append(
+                                f"/haptic-desktop held-space return from file browser left focus on {focus_after_hold!r} instead of 'Launcher'",
+                            )
+                    if not cycle_focus_to(page, "Models Gallery"):
+                        failures.append("/haptic-desktop could not refocus Models Gallery after returning to launcher")
+                    else:
+                        page.locator("#focus-activate").click()
                     page.wait_for_function(
                         """
                         () => {


### PR DESCRIPTION
## Summary
- make launcher returns land on a neutral launcher hub instead of a gallery tile
- suppress repeated held-key activation across scene transitions in the shared pointer emulator
- extend browser smoke coverage for the file-browser to launcher return path

## Validation
- `python -m pytest tests -v`
- `python -m compileall app tests run_app.py scripts`
- `python scripts\\browser_scene_smoke.py`

Closes #28