### PR TITLE
Feat: align Haptic Desktop file-type routing and home semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The current implementation provides real 3D workspace rendering across the spati
 
 ## Current Version
 
-`0.5.3`
+`0.5.4`
 
 ## Public Port
 
@@ -42,7 +42,7 @@ Operational workspace that translates text into Braille cells, lays them out on 
 
 ### Haptic Desktop
 
-Workspace-driven tactile desktop that now transitions through a launcher, paginated galleries, a file browser, item detail plaques, and opened scenes for models, text, and audio. The bundled demo workspace mirrors the full internal demo library so the gallery flow covers every bundled model, document, and audio sample.
+Workspace-driven tactile desktop that now transitions through a launcher, paginated galleries, a typed file browser, item detail plaques, and opened scenes for models, text, and audio. The bundled demo workspace mirrors the full internal demo library so the gallery flow covers every bundled model, document, and audio sample. The file browser uses distinct tactile 3D shapes for folders, models, texts, audio files, and unsupported files, and supported files dispatch directly into their corresponding runtime scene.
 
 ### Haptic Workspace Manager
 

--- a/app/core/haptic_workspace.py
+++ b/app/core/haptic_workspace.py
@@ -26,6 +26,34 @@ SUPPORTED_MODEL_SUFFIXES = {".obj"}
 SUPPORTED_TEXT_SUFFIXES = {".txt", ".html", ".htm", ".epub", ".md"}
 SUPPORTED_AUDIO_SUFFIXES = {".mp3", ".wav", ".ogg", ".m4a"}
 DEFAULT_SEGMENT_CHARS = 1200
+KIND_LABELS = {
+    "directory": "Folder",
+    "model": "3D Model",
+    "text": "Text",
+    "audio": "Audio",
+    "unsupported": "Unsupported file",
+}
+KIND_SHAPE_KEYS = {
+    "directory": "folder_tile",
+    "model": "polyhedral_model_tile",
+    "text": "braille_document_tile",
+    "audio": "speaker_wave_tile",
+    "unsupported": "blocked_file_tile",
+}
+KIND_OPEN_MODES = {
+    "directory": "file-browser",
+    "model": "open-model",
+    "text": "open-text",
+    "audio": "open-audio",
+    "unsupported": "unsupported",
+}
+KIND_OPEN_LABELS = {
+    "directory": "Open folder in the workspace file browser",
+    "model": "Open in the 3D model scene",
+    "text": "Open in the Braille reading scene",
+    "audio": "Open in the audio transport scene",
+    "unsupported": "Inspect unsupported file details",
+}
 
 
 def local_app_state_dir() -> Path:
@@ -115,6 +143,17 @@ def detect_entry_kind(path: Path) -> str:
     if suffix in SUPPORTED_AUDIO_SUFFIXES:
         return "audio"
     return "unsupported"
+
+
+def build_kind_contract(kind: str) -> dict[str, str]:
+    """Return the shared Haptic Desktop contract metadata for one entry kind."""
+    normalized_kind = kind if kind in KIND_LABELS else "unsupported"
+    return {
+        "kind_label": KIND_LABELS[normalized_kind],
+        "shape_key": KIND_SHAPE_KEYS[normalized_kind],
+        "open_mode": KIND_OPEN_MODES[normalized_kind],
+        "open_label": KIND_OPEN_LABELS[normalized_kind],
+    }
 
 
 def _read_workspace_descriptor(path: Path) -> dict[str, Any]:
@@ -270,12 +309,14 @@ def _resolve_workspace_item(workspace_slug: str, record: dict[str, Any], categor
         if model is None:
             raise ValueError(f"Unknown demo model reference: {ref}")
         payload["kind"] = "model"
+        payload.update(build_kind_contract("model"))
         payload["source"].update(
             {
                 "ref": ref,
                 "demo_model_slug": model["slug"],
                 "file_url": model["file_url"],
                 "title": model["title"],
+                "extension": ".obj",
             },
         )
         return payload
@@ -285,12 +326,14 @@ def _resolve_workspace_item(workspace_slug: str, record: dict[str, Any], categor
         if document is None:
             raise ValueError(f"Unknown library document reference: {ref}")
         payload["kind"] = "text"
+        payload.update(build_kind_contract("text"))
         payload["source"].update(
             {
                 "ref": ref,
                 "document_slug": document["slug"],
                 "text_endpoint": f"/api/library/documents/{document['slug']}",
                 "format": document["format"],
+                "extension": f".{document['format']}",
             },
         )
         return payload
@@ -300,12 +343,14 @@ def _resolve_workspace_item(workspace_slug: str, record: dict[str, Any], categor
         if audio is None:
             raise ValueError(f"Unknown library audio reference: {ref}")
         payload["kind"] = "audio"
+        payload.update(build_kind_contract("audio"))
         payload["source"].update(
             {
                 "ref": ref,
                 "audio_slug": audio["slug"],
                 "file_url": audio["file_url"],
                 "format": audio["format"],
+                "extension": f".{audio['format']}",
             },
         )
         return payload
@@ -314,10 +359,12 @@ def _resolve_workspace_item(workspace_slug: str, record: dict[str, Any], categor
         relative_path = _normalize_relative_path(source.get("relative_path", ""))
         file_path = _resolve_child_path(record["content_root"], relative_path)
         payload["kind"] = detect_entry_kind(file_path)
+        payload.update(build_kind_contract(payload["kind"]))
         payload["source"].update(
             {
                 "relative_path": relative_path,
                 "raw_file_endpoint": f"/api/haptic-workspaces/{workspace_slug}/raw-file?path={relative_path}",
+                "extension": file_path.suffix.lower(),
             },
         )
         if payload["kind"] == "text":
@@ -395,7 +442,9 @@ def build_workspace_browser_payload(slug: str, relative_path: str = "") -> dict[
             "kind": kind,
             "relative_path": child_relative,
             "size_bytes": child.stat().st_size if child.is_file() else 0,
+            "extension": child.suffix.lower() if child.is_file() else "",
         }
+        entry.update(build_kind_contract(kind))
         if kind == "directory":
             entry["child_count"] = sum(1 for _ in child.iterdir())
         else:
@@ -403,6 +452,7 @@ def build_workspace_browser_payload(slug: str, relative_path: str = "") -> dict[
                 "kind": "workspace_file",
                 "relative_path": child_relative,
                 "raw_file_endpoint": f"/api/haptic-workspaces/{slug}/raw-file?path={child_relative}",
+                "extension": child.suffix.lower(),
             }
             if kind == "text":
                 entry["source"]["text_endpoint"] = (

--- a/app/core/version.py
+++ b/app/core/version.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 APP_NAME = "FeelIT"
-APP_VERSION = "0.5.3"
+APP_VERSION = "0.5.4"
 APP_PUBLISHER = "Felipe Santibanez"
 
 

--- a/app/static/haptic_desktop.html
+++ b/app/static/haptic_desktop.html
@@ -190,7 +190,10 @@
         <ul>
           <li>Select the active workspace from the left panel, then load it into the scene engine.</li>
           <li>Move the pointer emulator with `W`, `A`, `S`, `D`, `Q`, and `E` and activate focused objects with `Space` or `Enter`.</li>
-          <li>Use tactile scene controls for the launcher, gallery start or file-browser root, back navigation, paging, opening content, and browsing the workspace file root.</li>
+          <li>Use distinct tactile object shapes in the file browser: folders, models, texts, audio files, and unsupported files are intentionally not represented by the same 3D form.</li>
+          <li>Supported files opened from the file browser now enter their corresponding runtime scene directly: models to the 3D model scene, texts to the Braille reading scene, and audio files to the audio transport scene.</li>
+          <li>Use `Home` to return to the exact gallery page or file-browser location that launched the current scene, and use `Launcher` to return to the workspace start scene.</li>
+          <li>Use tactile scene controls for launcher return, home return, gallery start or file-browser root, paging, opening content, and browsing the workspace file root.</li>
           <li>Returning to the launcher should land on the neutral launcher hub first, not on a specific gallery tile.</li>
           <li>Use spoken cues as a support channel while keeping the object shapes and scene changes as the primary interaction contract.</li>
         </ul>

--- a/app/static/js/haptic_desktop.js
+++ b/app/static/js/haptic_desktop.js
@@ -46,10 +46,10 @@ const CATEGORY_META = {
 };
 
 const FILE_KIND_META = {
-  directory: { title: "Folder", color: 0x58a6ff, actionLabel: "Open folder" },
-  model: { title: "3D Model", color: 0x58a6ff, actionLabel: "Inspect item details" },
-  text: { title: "Text", color: 0x7ee787, actionLabel: "Inspect item details" },
-  audio: { title: "Audio", color: 0xf2cc60, actionLabel: "Inspect item details" },
+  directory: { title: "Folder", color: 0x58a6ff, actionLabel: "Open folder in the workspace file browser" },
+  model: { title: "3D Model", color: 0x58a6ff, actionLabel: "Open in the 3D model scene" },
+  text: { title: "Text", color: 0x7ee787, actionLabel: "Open in the Braille reading scene" },
+  audio: { title: "Audio", color: 0xf2cc60, actionLabel: "Open in the audio transport scene" },
   unsupported: {
     title: "Unsupported file",
     color: 0xff7b72,
@@ -938,7 +938,10 @@ function updatePointerHover(position) {
 }
 
 async function activateFocusedTarget(source = "pointer") {
-  const targetId = state.hoveredTargetId ?? state.focusedTargetId;
+  const targetId =
+    source === "pointer"
+      ? state.hoveredTargetId ?? state.focusedTargetId
+      : state.focusedTargetId ?? state.hoveredTargetId;
   const target = state.targets.get(targetId);
   if (!target) {
     publishStatus("No tactile control is currently under the pointer.", "Ready", "no-target");
@@ -1097,10 +1100,20 @@ function galleryTilePositions(count) {
       new THREE.Vector3(1.18, 0.12, 0.02),
     ];
   }
+  if (count <= 3) {
+    return [
+      new THREE.Vector3(-1.48, 0.12, -0.26),
+      new THREE.Vector3(0, 0.12, 0.56),
+      new THREE.Vector3(1.48, 0.12, -0.26),
+    ].slice(0, count);
+  }
   return [
-    new THREE.Vector3(-1.48, 0.12, -0.26),
-    new THREE.Vector3(0, 0.12, 0.56),
-    new THREE.Vector3(1.48, 0.12, -0.26),
+    new THREE.Vector3(-1.48, 0.12, -0.72),
+    new THREE.Vector3(0, 0.12, -0.08),
+    new THREE.Vector3(1.48, 0.12, -0.72),
+    new THREE.Vector3(-1.48, 0.12, 0.62),
+    new THREE.Vector3(0, 0.12, 1.26),
+    new THREE.Vector3(1.48, 0.12, 0.62),
   ].slice(0, count);
 }
 
@@ -1110,6 +1123,22 @@ function resolveItemKind(item) {
 
 function kindMeta(kind) {
   return FILE_KIND_META[kind] ?? FILE_KIND_META.unsupported;
+}
+
+function kindSymbolBuilder(kind) {
+  if (kind === "model") {
+    return buildModelSymbol;
+  }
+  if (kind === "text") {
+    return buildTextSymbol;
+  }
+  if (kind === "audio") {
+    return buildAudioSymbol;
+  }
+  if (kind === "directory") {
+    return buildFolderSymbol;
+  }
+  return buildUnsupportedSymbol;
 }
 
 function itemRawFileUrl(item) {
@@ -1143,6 +1172,19 @@ function detailOriginLabel(origin) {
     return origin.path ? `File browser: ${origin.path}` : "File browser root";
   }
   return "Launcher";
+}
+
+function homeTargetLabel(origin) {
+  if (!origin) {
+    return "the workspace launcher";
+  }
+  if (origin.type === "gallery") {
+    return `${CATEGORY_META[origin.category].title}, page ${origin.page + 1}`;
+  }
+  if (origin.type === "file-browser") {
+    return origin.path ? `the file browser at ${origin.path}` : "the file browser root";
+  }
+  return "the workspace launcher";
 }
 
 function originStartConfig(origin) {
@@ -1182,25 +1224,32 @@ async function navigateToOriginStart(origin) {
   await navigateToLauncher();
 }
 
-function createGalleryItemTarget(item, position, onActivate) {
+async function navigateHome(origin) {
+  if (!origin) {
+    await navigateToLauncher();
+    return;
+  }
+  if (origin.type === "gallery") {
+    await navigateToGallery(origin.category, origin.page);
+    return;
+  }
+  if (origin.type === "file-browser") {
+    await navigateToFileBrowser(origin.path ?? "", origin.page ?? 0);
+    return;
+  }
+  await navigateToLauncher();
+}
+
+function createGalleryItemTarget(item, position, onActivate, actionLabel = null) {
   const kind = resolveItemKind(item);
   const meta = kindMeta(kind);
-  const symbolBuilder =
-    kind === "model"
-      ? buildModelSymbol
-      : kind === "text"
-        ? buildTextSymbol
-        : kind === "audio"
-          ? buildAudioSymbol
-          : kind === "directory"
-            ? buildFolderSymbol
-            : buildUnsupportedSymbol;
+  const symbolBuilder = kindSymbolBuilder(kind);
   const group = buildInteractiveTile(item.title, symbolBuilder, meta.color);
   createTarget({
     id: `item-${item.slug}`,
     title: item.title,
     type: meta.title,
-    actionLabel: meta.actionLabel,
+    actionLabel: actionLabel ?? item.open_label ?? meta.actionLabel,
     group,
     position,
     radius: 0.52,
@@ -1381,8 +1430,11 @@ async function navigateToGallery(category, page = 0) {
 
   const positions = galleryTilePositions(pageSlice.items.length);
   pageSlice.items.forEach((item, index) => {
-    createGalleryItemTarget(item, positions[index], async () =>
-      navigateToDetail(item, { type: "gallery", category, page: pageSlice.page }),
+    createGalleryItemTarget(
+      item,
+      positions[index],
+      async () => navigateToDetail(item, { type: "gallery", category, page: pageSlice.page }),
+      "Inspect item details and continue to the corresponding runtime scene",
     );
   });
   addGallerySummary(category, pageSlice, workspace.libraries[category].length);
@@ -1470,11 +1522,24 @@ async function navigateToFileBrowser(relativePath = "", page = 0) {
 
   const positions = galleryTilePositions(pageSlice.items.length);
   pageSlice.items.forEach((entry, index) => {
+    const origin = { type: "file-browser", path: payload.current_path, page: pageSlice.page };
     const onActivate =
       entry.kind === "directory"
         ? async () => navigateToFileBrowser(entry.relative_path, 0)
+        : entry.kind === "unsupported"
+          ? async () =>
+              navigateToDetail(
+                {
+                  ...entry,
+                  source: entry.source ?? {
+                    kind: "workspace_file",
+                    relative_path: entry.relative_path,
+                  },
+                },
+                origin,
+              )
         : async () =>
-            navigateToDetail(
+            openItemScene(
               {
                 ...entry,
                 source: entry.source ?? {
@@ -1482,11 +1547,9 @@ async function navigateToFileBrowser(relativePath = "", page = 0) {
                   relative_path: entry.relative_path,
                 },
               },
-              { type: "file-browser", path: payload.current_path, page: pageSlice.page },
+              origin,
             );
     createGalleryItemTarget(entry, positions[index], onActivate);
-    const target = state.targets.get(`item-${entry.slug}`);
-    target.actionLabel = entry.kind === "directory" ? "Open folder" : target.actionLabel;
   });
 
   addControlTarget({
@@ -1555,7 +1618,7 @@ async function navigateToFileBrowser(relativePath = "", page = 0) {
   finishSceneBuild({
     code: "file-browser",
     title: "Workspace File Browser",
-    subtitle: "Directory buttons, supported-file buttons, and unsupported-file placeholders share the same bounded tactile map.",
+    subtitle: "Directory buttons and typed file buttons share one tactile map, while supported files dispatch directly into their corresponding runtime scenes.",
     context: workspace.title,
     path: payload.current_path || payload.current_label,
     pagination: `${pageSlice.page + 1} / ${pageSlice.pageCount}`,
@@ -1569,22 +1632,6 @@ async function navigateToFileBrowser(relativePath = "", page = 0) {
 
 function truncateDetailText(text) {
   return text.length > 24 ? `${text.slice(0, 24)}…` : text;
-}
-
-async function navigateBackToOrigin(origin) {
-  if (!origin) {
-    await navigateToLauncher();
-    return;
-  }
-  if (origin.type === "gallery") {
-    await navigateToGallery(origin.category, origin.page);
-    return;
-  }
-  if (origin.type === "file-browser") {
-    await navigateToFileBrowser(origin.path ?? "", origin.page ?? 0);
-    return;
-  }
-  await navigateToLauncher();
 }
 
 async function navigateToDetail(item, origin) {
@@ -1611,14 +1658,7 @@ async function navigateToDetail(item, origin) {
   plaque.position.set(-0.2, 0.12, -0.22);
   state.sceneApi.world.add(plaque);
 
-  const symbolBuilder =
-    kind === "model"
-      ? buildModelSymbol
-      : kind === "text"
-        ? buildTextSymbol
-        : kind === "audio"
-          ? buildAudioSymbol
-          : buildUnsupportedSymbol;
+  const symbolBuilder = kindSymbolBuilder(kind);
   const icon = buildInteractiveTile(meta.title, symbolBuilder, meta.color);
   icon.position.set(1.6, 0.12, -0.2);
   icon.scale.setScalar(0.92);
@@ -1656,20 +1696,20 @@ async function navigateToDetail(item, origin) {
     });
   }
   addControlTarget({
-    id: "detail-back",
-    label: "Back",
+    id: "detail-home",
+    label: "Home",
     type: "Control",
-    actionLabel: `Return to ${detailOriginLabel(origin)}`,
+    actionLabel: `Return to ${homeTargetLabel(origin)}`,
     kind: "back",
     color: 0x58a6ff,
     position: new THREE.Vector3(originStart ? 0.62 : 0, 0.12, 1.42),
-    onActivate: async () => navigateBackToOrigin(origin),
+    onActivate: async () => navigateHome(origin),
   });
   addControlTarget({
     id: "detail-open",
     label: kind === "unsupported" ? "Unavailable" : "Open",
     type: "Control",
-    actionLabel: kind === "unsupported" ? "The selected file is not supported yet" : `Open ${item.title}`,
+    actionLabel: kind === "unsupported" ? "The selected file is not supported yet" : item.open_label ?? `Open ${item.title}`,
     kind: "open",
     color: meta.color,
     position: new THREE.Vector3(originStart ? 1.74 : 1.2, 0.12, 1.42),
@@ -1774,14 +1814,14 @@ async function navigateToModelScene(item, origin) {
     });
   }
   addControlTarget({
-    id: "model-back",
-    label: "Back",
+    id: "model-home",
+    label: "Home",
     type: "Control",
-    actionLabel: `Return to ${detailOriginLabel(origin)}`,
+    actionLabel: `Return to ${homeTargetLabel(origin)}`,
     kind: "back",
     color: 0x58a6ff,
     position: new THREE.Vector3(originStart ? 0.6 : 0, 0.12, 1.7),
-    onActivate: async () => navigateBackToOrigin(origin),
+    onActivate: async () => navigateHome(origin),
   });
 
   state.sceneApi.setBoundarySize(
@@ -1802,13 +1842,13 @@ async function navigateToModelScene(item, origin) {
   finishSceneBuild({
     code: "open-model",
     title: "3D Model Scene",
-    subtitle: "The opened object shares space with tactile launcher, origin-start, and back-return controls.",
+    subtitle: "The opened object shares space with tactile launcher, origin-start, and home-return controls.",
     context: detailOriginLabel(origin),
     path: item.source?.relative_path ?? item.source?.demo_model_slug ?? item.slug,
     pagination: "1 / 1",
     idleMessage: `Pointer moving across the opened 3D model ${item.title}.`,
   });
-  focusTarget("model-back", { source: "scene", movePointer: false });
+  focusTarget("model-home", { source: "scene", movePointer: false });
   publishStatus(`Opened ${item.title} in the model scene.`, "Ready", `open-model-${item.slug}`);
 }
 
@@ -1957,14 +1997,14 @@ function renderTextScene(token = state.sceneBuildToken) {
     });
   }
   addControlTarget({
-    id: "text-back",
-    label: "Back",
+    id: "text-home",
+    label: "Home",
     type: "Control",
-    actionLabel: `Return to ${detailOriginLabel(textScene.origin)}`,
+    actionLabel: `Return to ${homeTargetLabel(textScene.origin)}`,
     kind: "back",
     color: 0x58a6ff,
     position: new THREE.Vector3(0.16, 0.12, 1.78),
-    onActivate: async () => navigateBackToOrigin(textScene.origin),
+    onActivate: async () => navigateHome(textScene.origin),
   });
   addControlTarget({
     id: "text-prev",
@@ -2114,14 +2154,14 @@ function renderAudioScene(token = state.sceneBuildToken) {
     });
   }
   addControlTarget({
-    id: "audio-back",
-    label: "Back",
+    id: "audio-home",
+    label: "Home",
     type: "Control",
-    actionLabel: `Return to ${detailOriginLabel(audioScene.origin)}`,
+    actionLabel: `Return to ${homeTargetLabel(audioScene.origin)}`,
     kind: "back",
     color: 0x58a6ff,
     position: new THREE.Vector3(-0.04, 0.12, 1.46),
-    onActivate: async () => navigateBackToOrigin(audioScene.origin),
+    onActivate: async () => navigateHome(audioScene.origin),
   });
   addControlTarget({
     id: "audio-toggle",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,7 +60,7 @@ The object explorer, Braille reader, and haptic desktop each render an actual 3D
 
 - the object explorer stages real OBJ meshes inside a bounded scene
 - the Braille reader renders the tactile board as raised 3D geometry with scene-native navigation controls
-- the desktop mode renders a workspace-driven launcher, galleries, detail plaques, and opened content scenes
+- the desktop mode renders a workspace-driven launcher, galleries, a typed file browser, detail plaques, and opened content scenes
 - the shared pointer emulator behaves as a stylus-like proxy when no hardware device is attached
 
 Auxiliary 2D views are secondary and are only used when they help interpretation or debugging.
@@ -168,7 +168,9 @@ Current file:
 9. The object explorer stages an OBJ mesh and tactile material context on a visible exploration plinth.
 10. The Braille reader loads a bundled document segment, requests `/api/braille/preview`, and realizes the response as a 3D tactile board with in-scene controls.
 11. Haptic Desktop moves between launcher, gallery, file-browser, detail, and opened-content scenes using workspace-driven payloads.
-12. Runtime and device status are reflected in the current workspace.
+12. File-browser entries use kind-specific tactile forms and dispatch supported files directly into the corresponding runtime scene.
+13. Opened desktop scenes expose `Home` for return to the exact origin and `Launcher` for return to the workspace start scene.
+14. Runtime and device status are reflected in the current workspace.
 
 ## Future Extension Points
 

--- a/docs/development_history.md
+++ b/docs/development_history.md
@@ -15,6 +15,21 @@ The archived user manual describes the software as a digital-to-relief presentat
 
 ## Modern Rebuild Timeline
 
+### v0.5.4 (2026-03-29)
+
+Patch release focused on typed Haptic Desktop file-browser interaction, contextual Home or Launcher return semantics, and stronger workspace item contracts.
+
+Delivered:
+
+- Added explicit file-kind contracts for Haptic Desktop entries, including tactile shape keys, mode-routing metadata, and mode-specific action labels.
+- Routed supported file-browser files into their corresponding runtime scenes while keeping Home tied to the exact origin and Launcher tied to the workspace start scene.
+- Fixed fallback activation priority for focused desktop targets and extended automated coverage for file-kind mode mapping plus Haptic Desktop scene flow.
+
+Rationale:
+
+- Keep Haptic Desktop navigation consistent for blind-first workflows by making file type, tactile representation, mode dispatch, and return semantics follow one explicit contract.
+- Prevent focus-driven fallback interaction from silently activating the wrong target when the pointer and fallback focus diverge.
+
 ### v0.5.3 (2026-03-29)
 
 Patch release focused on deterministic launcher return semantics in Haptic Desktop and regression coverage for held activation across scene transitions.

--- a/docs/implementation_gap_audit.md
+++ b/docs/implementation_gap_audit.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document separates what FeelIT `0.5.3` demonstrably implements today from what remains partial, planned, or hardware-dependent.
+This document separates what FeelIT `0.5.4` demonstrably implements today from what remains partial, planned, or hardware-dependent.
 
 It is intentionally conservative. If a behavior is not visible in the runtime, testable through the current repo, or clearly encoded in the shipped code path, it is not treated here as delivered.
 
@@ -84,8 +84,10 @@ Implemented:
 - launcher scene with a neutral launcher hub plus curated entry points for models, texts, audio, and workspace file browsing
 - paginated gallery scenes backed by workspace payloads
 - bundled demo-workspace galleries synchronized against the full internal model, text, and audio catalogs
-- explicit in-scene Launcher plus Start or Root return controls across gallery, browser, detail, and opened-content scenes
+- typed file-browser entries with distinct tactile forms for folders, models, text files, audio files, and unsupported files
+- explicit in-scene Launcher, Home, and Start or Root return controls across gallery, browser, detail, and opened-content scenes
 - file-browser scene rooted in the configured workspace path
+- direct mode dispatch from the file browser for supported models, text files, and audio files
 - detail plaque scene that exposes the content name before opening it
 - opened scenes for 3D models, Braille reading, and audio transport
 - pointer-driven focus and activation across the current scene's tactile controls

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -93,11 +93,12 @@ Current use:
 - load the bundled demo workspace or a registered external workspace
 - use the bundled demo workspace as a full internal-library baseline covering every bundled model, document, and audio sample
 - start in a tactile launcher with a neutral launcher hub plus entry objects for models, texts, audio, and the workspace file browser
-- move through smaller paginated gallery scenes and a workspace-root file browser
+- move through smaller paginated gallery scenes and a workspace-root file browser where folders, models, texts, audio files, and unsupported files use different tactile 3D shapes
 - use explicit in-scene `Launcher` controls plus `Start` or `Root` controls to jump back to the main menu or the beginning of the active gallery or browser flow
-- expect `Launcher` to return to the neutral launcher hub, while `Back` returns to the previous scene and `Start` or `Root` return to the beginning of the active gallery or browser flow
+- expect `Launcher` to return to the neutral launcher hub, while `Home` returns to the exact gallery page or file-browser location that launched the current scene and `Start` or `Root` return to the beginning of the active gallery or browser flow
 - open a detail plaque that exposes the content name before opening the real scene
 - open 3D model scenes, Braille reading scenes, and audio transport scenes with scene-native return controls
+- from the file browser, open supported files directly in their corresponding runtime mode: models in the 3D model scene, texts in the Braille reading scene, and audio files in the audio transport scene
 
 Current keyboard cues:
 

--- a/installer/pyinstaller_version_info.txt
+++ b/installer/pyinstaller_version_info.txt
@@ -1,7 +1,7 @@
 VSVersionInfo(
   ffi=FixedFileInfo(
-    filevers=(0, 5, 3, 0),
-    prodvers=(0, 5, 3, 0),
+    filevers=(0, 5, 4, 0),
+    prodvers=(0, 5, 4, 0),
     mask=0x3F,
     flags=0x0,
     OS=0x40004,
@@ -16,11 +16,11 @@ VSVersionInfo(
         [
           StringStruct('CompanyName', 'Felipe Santibanez'),
           StringStruct('FileDescription', 'FeelIT'),
-          StringStruct('FileVersion', '0.5.3.0'),
+          StringStruct('FileVersion', '0.5.4.0'),
           StringStruct('InternalName', 'FeelIT'),
           StringStruct('OriginalFilename', 'FeelIT.exe'),
           StringStruct('ProductName', 'FeelIT'),
-          StringStruct('ProductVersion', '0.5.3')
+          StringStruct('ProductVersion', '0.5.4')
         ]
       )
     ]),

--- a/installer/version.iss
+++ b/installer/version.iss
@@ -1,4 +1,4 @@
 #define AppName "FeelIT"
-#define AppVersion "0.5.3"
+#define AppVersion "0.5.4"
 #define AppPublisher "Felipe Santibanez"
 #define AppExeName "FeelIT.exe"

--- a/scripts/browser_scene_smoke.py
+++ b/scripts/browser_scene_smoke.py
@@ -69,7 +69,7 @@ def focused_label(page) -> str:
     return (page.locator("#desktop-focus-label").text_content() or "").strip()
 
 
-def cycle_focus_to(page, label: str, *, max_steps: int = 12) -> bool:
+def cycle_focus_to(page, label: str, *, max_steps: int = 20) -> bool:
     """Move the fallback focus until the requested label is active."""
     for _ in range(max_steps):
         if focused_label(page) == label:
@@ -90,6 +90,8 @@ def run_browser_smoke(base_url: str, screenshot_dir: Path) -> None:
         for scene in SCENES:
             console_messages: list[str] = []
             page_errors: list[str] = []
+            desktop_gallery_loaded = False
+            desktop_gallery_paginated = False
             page = browser.new_page(viewport={"width": 1600, "height": 1000}, device_scale_factor=1)
             page.on(
                 "console",
@@ -143,6 +145,7 @@ def run_browser_smoke(base_url: str, screenshot_dir: Path) -> None:
                     """,
                     timeout=15_000,
                 )
+                desktop_gallery_loaded = True
                 if not cycle_focus_to(page, "Next"):
                     failures.append("/haptic-desktop could not focus the gallery Next control")
                 else:
@@ -156,6 +159,47 @@ def run_browser_smoke(base_url: str, screenshot_dir: Path) -> None:
                         """,
                         timeout=15_000,
                     )
+                    desktop_gallery_paginated = True
+                if not cycle_focus_to(page, "Female Figure"):
+                    failures.append("/haptic-desktop could not focus a page-2 model gallery item")
+                else:
+                    page.locator("#focus-activate").click()
+                    page.wait_for_function(
+                        """
+                        () => {
+                          const sceneCode = document.querySelector('#desktop-scene-code')?.textContent?.trim() ?? '';
+                          return sceneCode === 'detail-model';
+                        }
+                        """,
+                        timeout=15_000,
+                    )
+                    if not cycle_focus_to(page, "Open"):
+                        failures.append("/haptic-desktop could not focus the detail Open control")
+                    else:
+                        page.locator("#focus-activate").click()
+                        page.wait_for_function(
+                            """
+                            () => {
+                              const sceneCode = document.querySelector('#desktop-scene-code')?.textContent?.trim() ?? '';
+                              return sceneCode === 'open-model';
+                            }
+                            """,
+                            timeout=15_000,
+                        )
+                    if not cycle_focus_to(page, "Home"):
+                        failures.append("/haptic-desktop could not focus the model Home control")
+                    else:
+                        page.locator("#focus-activate").click()
+                        page.wait_for_function(
+                            """
+                            () => {
+                              const sceneCode = document.querySelector('#desktop-scene-code')?.textContent?.trim() ?? '';
+                              const pagination = document.querySelector('#desktop-pagination')?.textContent?.trim() ?? '';
+                              return sceneCode === 'models-gallery' && pagination.startsWith('2 /');
+                            }
+                            """,
+                            timeout=15_000,
+                        )
                 if not cycle_focus_to(page, "Start"):
                     failures.append("/haptic-desktop could not focus the gallery Start control")
                 else:
@@ -198,38 +242,52 @@ def run_browser_smoke(base_url: str, screenshot_dir: Path) -> None:
                               return sceneCode === 'file-browser';
                             }
                             """,
-                            timeout=15_000,
-                        )
-                    if not cycle_focus_to(page, "Launcher"):
-                        failures.append("/haptic-desktop could not focus the file-browser Launcher control")
-                    else:
-                        page.keyboard.down("Space")
-                        page.wait_for_timeout(900)
-                        page.keyboard.up("Space")
-                        page.wait_for_timeout(700)
-                        scene_after_hold = (page.locator("#desktop-scene-code").text_content() or "").strip()
-                        focus_after_hold = focused_label(page)
-                        if scene_after_hold != "launcher":
-                            failures.append(
-                                f"/haptic-desktop held-space return from file browser ended on {scene_after_hold!r} instead of 'launcher'",
-                            )
-                        if focus_after_hold != "Launcher":
-                            failures.append(
-                                f"/haptic-desktop held-space return from file browser left focus on {focus_after_hold!r} instead of 'Launcher'",
-                            )
-                    if not cycle_focus_to(page, "Models Gallery"):
-                        failures.append("/haptic-desktop could not refocus Models Gallery after returning to launcher")
-                    else:
-                        page.locator("#focus-activate").click()
-                    page.wait_for_function(
-                        """
-                        () => {
-                          const sceneCode = document.querySelector('#desktop-scene-code')?.textContent?.trim() ?? '';
-                          return sceneCode === 'models-gallery';
-                        }
-                        """,
                         timeout=15_000,
                     )
+                    if not cycle_focus_to(page, "documents"):
+                        failures.append("/haptic-desktop could not focus the documents folder from the file browser root")
+                    else:
+                        if not cycle_focus_to(page, "Launcher"):
+                            failures.append("/haptic-desktop could not focus the file-browser Launcher control")
+                        else:
+                            page.keyboard.down("Space")
+                            page.wait_for_timeout(900)
+                            page.keyboard.up("Space")
+                            page.wait_for_timeout(700)
+                            scene_after_hold = (page.locator("#desktop-scene-code").text_content() or "").strip()
+                            focus_after_hold = focused_label(page)
+                            if scene_after_hold != "launcher":
+                                failures.append(
+                                    f"/haptic-desktop held-space return from file browser ended on {scene_after_hold!r} instead of 'launcher'",
+                                )
+                            if focus_after_hold != "Launcher":
+                                failures.append(
+                                    f"/haptic-desktop held-space return from file browser left focus on {focus_after_hold!r} instead of 'Launcher'",
+                                )
+                        if not cycle_focus_to(page, "File Browser"):
+                            failures.append("/haptic-desktop could not refocus File Browser from the launcher after the held-space test")
+                        else:
+                            page.locator("#focus-activate").click()
+                            page.wait_for_timeout(1_000)
+                        if not cycle_focus_to(page, "documents"):
+                            failures.append("/haptic-desktop could not refocus the documents folder from the file browser root")
+                        else:
+                            page.locator("#focus-activate").click()
+                            page.wait_for_timeout(1_200)
+                            scene_in_documents = (page.locator("#desktop-scene-code").text_content() or "").strip()
+                            path_in_documents = (page.locator("#desktop-scene-path").text_content() or "").strip()
+                            if scene_in_documents != "file-browser" or "documents" not in path_in_documents:
+                                failures.append(
+                                    f"/haptic-desktop did not enter the documents folder correctly; scene={scene_in_documents!r} path={path_in_documents!r}",
+                                )
+                    if not cycle_focus_to(page, "alice_in_wonderland.txt"):
+                        failures.append("/haptic-desktop could not focus a supported text file inside documents")
+                    else:
+                        focus_action = (page.locator("#desktop-focus-action").text_content() or "").strip()
+                        if "Braille reading scene" not in focus_action:
+                            failures.append(
+                                f"/haptic-desktop supported text file did not advertise the Braille reading scene action; action={focus_action!r}",
+                            )
             page.wait_for_timeout(1_200)
 
             screenshot_path = screenshot_dir / f"{scene.route.strip('/').replace('-', '_')}.png"
@@ -272,14 +330,13 @@ def run_browser_smoke(base_url: str, screenshot_dir: Path) -> None:
                 workspace_options = page.locator("#desktop-workspace-select option").count()
                 workspace_title = (page.locator("#desktop-workspace-title").text_content() or "").strip()
                 scene_code = (page.locator("#desktop-scene-code").text_content() or "").strip()
-                pagination = (page.locator("#desktop-pagination").text_content() or "").strip()
                 if workspace_options == 0:
                     failures.append("/haptic-desktop did not populate the workspace selector")
                 if workspace_title in {"", "Loading", "No workspace"}:
                     failures.append("/haptic-desktop did not initialize the active workspace summary")
-                if scene_code != "models-gallery":
+                if not desktop_gallery_loaded:
                     failures.append("/haptic-desktop did not navigate from launcher into the models gallery")
-                if pagination in {"", "--", "1 / 1"}:
+                if not desktop_gallery_paginated:
                     failures.append("/haptic-desktop models gallery did not expose real pagination")
                 if scene_code in {"", "--", "Loading"}:
                     failures.append("/haptic-desktop did not initialize the scene code")

--- a/tests/test_haptic_workspace.py
+++ b/tests/test_haptic_workspace.py
@@ -28,6 +28,12 @@ def test_demo_workspace_payload_resolves_bundled_libraries() -> None:
     assert any(item["kind"] == "model" for item in payload["libraries"]["models"])
     assert any(item["kind"] == "text" for item in payload["libraries"]["texts"])
     assert any(item["kind"] == "audio" for item in payload["libraries"]["audio"])
+    assert all(item["open_mode"] == "open-model" for item in payload["libraries"]["models"])
+    assert all(item["shape_key"] == "polyhedral_model_tile" for item in payload["libraries"]["models"])
+    assert all(item["open_mode"] == "open-text" for item in payload["libraries"]["texts"])
+    assert all(item["shape_key"] == "braille_document_tile" for item in payload["libraries"]["texts"])
+    assert all(item["open_mode"] == "open-audio" for item in payload["libraries"]["audio"])
+    assert all(item["shape_key"] == "speaker_wave_tile" for item in payload["libraries"]["audio"])
 
 
 def test_demo_workspace_payload_covers_all_bundled_assets() -> None:
@@ -50,6 +56,19 @@ def test_demo_workspace_browser_payload_lists_internal_library_entries() -> None
     assert payload["current_path"] == ""
     assert "audio" in entry_titles
     assert "documents" in entry_titles
+    documents_entry = next(entry for entry in payload["entries"] if entry["title"] == "documents")
+    assert documents_entry["kind"] == "directory"
+    assert documents_entry["open_mode"] == "file-browser"
+    assert documents_entry["shape_key"] == "folder_tile"
+
+
+def test_demo_workspace_browser_payload_maps_text_files_to_braille_scene() -> None:
+    payload = haptic_workspace.build_workspace_browser_payload("feelit_demo_workspace", "documents")
+    text_entry = next(entry for entry in payload["entries"] if entry["title"] == "alice_in_wonderland.txt")
+    assert text_entry["kind"] == "text"
+    assert text_entry["open_mode"] == "open-text"
+    assert text_entry["shape_key"] == "braille_document_tile"
+    assert text_entry["open_label"] == "Open in the Braille reading scene"
 
 
 def test_create_workspace_file_auto_populates_supported_assets(tmp_path, monkeypatch) -> None:
@@ -152,3 +171,27 @@ def test_haptic_workspace_api_returns_demo_workspace_payload_browse_and_text() -
     assert detail_response.json()["slug"] == "feelit_demo_workspace"
     assert any(entry["title"] == "documents" for entry in browse_response.json()["entries"])
     assert "Alice" in text_response.json()["text"]
+
+
+def test_detect_entry_kind_maps_supported_file_types_to_modes(tmp_path) -> None:
+    model_path = tmp_path / "shape.obj"
+    model_path.write_text("v 0 0 0\n", encoding="utf-8")
+    text_path = tmp_path / "notes.md"
+    text_path.write_text("# sample", encoding="utf-8")
+    audio_path = tmp_path / "clip.ogg"
+    audio_path.write_bytes(b"OggS")
+    unsupported_path = tmp_path / "blob.bin"
+    unsupported_path.write_bytes(b"\x00\x01")
+    folder_path = tmp_path / "folder"
+    folder_path.mkdir()
+
+    assert haptic_workspace.detect_entry_kind(folder_path) == "directory"
+    assert haptic_workspace.build_kind_contract("directory")["open_mode"] == "file-browser"
+    assert haptic_workspace.detect_entry_kind(model_path) == "model"
+    assert haptic_workspace.build_kind_contract("model")["open_mode"] == "open-model"
+    assert haptic_workspace.detect_entry_kind(text_path) == "text"
+    assert haptic_workspace.build_kind_contract("text")["open_mode"] == "open-text"
+    assert haptic_workspace.detect_entry_kind(audio_path) == "audio"
+    assert haptic_workspace.build_kind_contract("audio")["open_mode"] == "open-audio"
+    assert haptic_workspace.detect_entry_kind(unsupported_path) == "unsupported"
+    assert haptic_workspace.build_kind_contract("unsupported")["open_mode"] == "unsupported"


### PR DESCRIPTION
## Summary
- add explicit file-kind contracts for Haptic Desktop workspace items, including tactile shape keys, open-mode metadata, and action labels
- route supported file-browser files directly into their corresponding runtime scenes
- align `Home` with the exact gallery or file-browser origin and keep `Launcher` as the workspace start scene
- fix fallback activation priority and expand workspace and browser-smoke coverage

## Validation
- `python -m pytest tests -v`
- `python -m compileall app tests run_app.py scripts`
- `python scripts\\browser_scene_smoke.py`

Closes #30