### PR TITLE
Docs: refresh FeelIT SVG suite and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Modern accessibility-centered haptic application for tactile 3D object explorati
 
 ## Overview
 
-FeelIT is a modernization of a university-era accessibility project focused on giving people with visual impairment a richer way to access shape, texture, and text through bounded haptic interaction. The modern repository is organized as a multi-workspace application with four dedicated routes rather than a single scrolling page:
+FeelIT is a modernization of an accessibility project originally developed by Felipe Santibanez during his Electronic Engineering studies in Concepcion, Chile. It focuses on giving people with visual impairment a richer way to access shape, texture, and text through bounded haptic interaction. The modern repository is organized as a multi-workspace application with four dedicated routes rather than a single scrolling page:
 
 - `/object-explorer`
 - `/braille-reader`
@@ -14,6 +14,12 @@ FeelIT is a modernization of a university-era accessibility project focused on g
 - `/haptic-workspace-manager`
 
 The current implementation provides real 3D workspace rendering across the spatial modes, a stylus-style pointer emulator for no-device execution, scene-native tactile controls in the Braille world, visible startup diagnostics for failed workspace boot, bundled OBJ demo assets, a bundled public-domain reading and audio library, a structured `haptic_workspace` format with a Workspace Manager route, and a null-hardware-safe runtime foundation for future physical device integration.
+
+## Interaction Diagrams
+
+![FeelIT mode map](docs/svg/mode_map.svg)
+
+![FeelIT Braille pipeline](docs/svg/braille_pipeline.svg)
 
 ## Current Version
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,6 +16,18 @@ This document defines the current system architecture for the modern FeelIT rebu
 
 ![Architecture](svg/architecture.svg)
 
+## Mode Map
+
+![Mode Map](svg/mode_map.svg)
+
+This mode map should always reflect the current shipped route set, current maturity of each route, and the current blind-first interaction contract.
+
+## Braille Runtime Pipeline
+
+![Braille Pipeline](svg/braille_pipeline.svg)
+
+The Braille pipeline diagram should stay aligned with the real reading workflow, including the current scene-native library launcher, segment loading, preview translation, and reading-world controls.
+
 ## Frontend Architecture
 
 The frontend follows the workbench pattern used by the stronger reference repositories.
@@ -169,7 +181,7 @@ Current file:
 10. The Braille reader loads the bundled library catalog, opens a document from a scene-native launcher, requests `/api/braille/preview`, and realizes the response as a 3D tactile board with in-scene page, segment, and library-return controls.
 11. Haptic Desktop moves between launcher, gallery, file-browser, detail, and opened-content scenes using workspace-driven payloads.
 12. File-browser entries use kind-specific tactile forms and dispatch supported files directly into the corresponding runtime scene.
-13. Opened desktop scenes expose `Home` for return to the exact origin and `Launcher` for return to the workspace start scene.
+13. Opened desktop scenes expose `Gallery` or `Browser` returns to the exact origin context and `Launcher` for return to the workspace start scene.
 14. Runtime and device status are reflected in the current workspace.
 
 ## Future Extension Points

--- a/docs/implementation_gap_audit.md
+++ b/docs/implementation_gap_audit.md
@@ -86,7 +86,7 @@ Implemented:
 - paginated gallery scenes backed by workspace payloads
 - bundled demo-workspace galleries synchronized against the full internal model, text, and audio catalogs
 - typed file-browser entries with distinct tactile forms for folders, models, text files, audio files, and unsupported files
-- explicit in-scene Launcher, Home, and Start or Root return controls across gallery, browser, detail, and opened-content scenes
+- explicit in-scene Launcher, Gallery or Browser, and Start or Root return controls across gallery, browser, detail, and opened-content scenes
 - file-browser scene rooted in the configured workspace path
 - direct mode dispatch from the file browser for supported models, text files, and audio files
 - detail plaque scene that exposes the content name before opening it

--- a/docs/scope_and_motivation.md
+++ b/docs/scope_and_motivation.md
@@ -4,7 +4,7 @@
 
 FeelIT originates from an accessibility project conceived to help people with visual impairment interact with information that is normally delivered as visual shape, texture, or spatial arrangement.
 
-The original university-era effort explored digital-to-Braille conversion and optional haptic interaction. The modern rebuild expands that idea into a broader interaction platform while remaining honest about what the preserved legacy actually confirms.
+The original effort was developed by Felipe Santibanez during his Electronic Engineering studies in Concepcion, Chile, and explored digital-to-Braille conversion with optional haptic interaction. The modern rebuild expands that idea into a broader interaction platform while remaining honest about what the preserved legacy actually confirms.
 
 ## Core Motivation
 

--- a/docs/svg/architecture.svg
+++ b/docs/svg/architecture.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="940" viewBox="0 0 1600 940" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="980" viewBox="0 0 1600 980" role="img" aria-labelledby="title desc">
   <title id="title">FeelIT architecture</title>
-  <desc id="desc">Architecture diagram for FeelIT showing frontend workspaces, shared API and domain services, haptic runtime, packaging flow, and preserved legacy evidence.</desc>
+  <desc id="desc">Architecture diagram for FeelIT showing four frontend routes, shared API and domain services, scene runtime and haptic boundary, and release governance that keeps documentation and SVG diagrams synchronized with the shipped state.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#0d1117"/>
-      <stop offset="55%" stop-color="#101725"/>
+      <stop offset="55%" stop-color="#111827"/>
       <stop offset="100%" stop-color="#161b22"/>
     </linearGradient>
     <linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
@@ -12,7 +12,7 @@
       <stop offset="100%" stop-color="#101722"/>
     </linearGradient>
     <linearGradient id="panelSoft" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#131d2b"/>
+      <stop offset="0%" stop-color="#142030"/>
       <stop offset="100%" stop-color="#0f1724"/>
     </linearGradient>
     <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
@@ -32,154 +32,170 @@
       .body { font: 400 16px 'Segoe UI', sans-serif; fill: #9fb0c3; }
       .small { font: 400 14px 'Segoe UI', sans-serif; fill: #8b949e; }
       .mono { font: 400 14px Consolas, monospace; fill: #d7e2ee; }
-      .legend { font: 600 14px 'Segoe UI', sans-serif; fill: #c9d5e2; }
+      .legend { font: 600 14px 'Segoe UI', sans-serif; fill: #d3deea; }
       .badge { font: 700 12px 'Segoe UI', sans-serif; fill: #0d1117; letter-spacing: 1px; }
       .iconStroke { stroke: #e6edf3; stroke-width: 2.2; stroke-linecap: round; stroke-linejoin: round; fill: none; }
       .iconFillBlue { fill: rgba(121,192,255,0.22); stroke: #79c0ff; stroke-width: 1.6; }
-      .iconFillGreen { fill: rgba(126,231,135,0.18); stroke: #7ee787; stroke-width: 1.6; }
-      .iconFillPurple { fill: rgba(194,151,255,0.18); stroke: #c297ff; stroke-width: 1.6; }
-      .iconFillOrange { fill: rgba(255,166,87,0.18); stroke: #ffa657; stroke-width: 1.6; }
-      .iconFillRed { fill: rgba(255,123,114,0.18); stroke: #ff7b72; stroke-width: 1.6; }
-      .iconFillYellow { fill: rgba(242,204,96,0.18); stroke: #f2cc60; stroke-width: 1.6; }
+      .iconFillGreen { fill: rgba(126,231,135,0.20); stroke: #7ee787; stroke-width: 1.6; }
+      .iconFillPurple { fill: rgba(194,151,255,0.20); stroke: #c297ff; stroke-width: 1.6; }
+      .iconFillOrange { fill: rgba(255,166,87,0.20); stroke: #ffa657; stroke-width: 1.6; }
+      .iconFillYellow { fill: rgba(242,204,96,0.20); stroke: #f2cc60; stroke-width: 1.6; }
     </style>
   </defs>
 
-  <rect width="1600" height="940" fill="url(#bg)"/>
-  <circle cx="1460" cy="150" r="240" fill="#58a6ff" opacity="0.06"/>
-  <circle cx="180" cy="820" r="220" fill="#39d2c0" opacity="0.05"/>
-  <rect x="42" y="42" width="1516" height="856" rx="28" fill="none" stroke="#30363d" stroke-width="2"/>
+  <rect width="1600" height="980" fill="url(#bg)"/>
+  <circle cx="1460" cy="170" r="240" fill="#58a6ff" opacity="0.06"/>
+  <circle cx="210" cy="860" r="220" fill="#39d2c0" opacity="0.05"/>
+  <rect x="42" y="42" width="1516" height="896" rx="28" fill="none" stroke="#30363d" stroke-width="2"/>
 
   <text x="78" y="102" class="title">FeelIT Architecture</text>
-  <text x="78" y="136" class="subtitle">Three dedicated workspaces share one release-governed runtime, one tactile domain layer, and one haptic abstraction boundary.</text>
+  <text x="78" y="136" class="subtitle">Four dedicated routes share one runtime, one domain core, and one release discipline that keeps docs and SVGs synchronized with shipped behavior.</text>
 
-  <rect x="78" y="172" width="204" height="30" rx="15" fill="#79c0ff"/>
-  <text x="101" y="192" class="lane">FRONTEND WORKSPACES</text>
-  <rect x="580" y="172" width="214" height="30" rx="15" fill="#7ee787"/>
-  <text x="604" y="192" class="lane">API AND DOMAIN CORE</text>
-  <rect x="1082" y="172" width="232" height="30" rx="15" fill="#ffa657"/>
-  <text x="1108" y="192" class="lane">RUNTIME AND DELIVERY</text>
+  <rect x="78" y="174" width="224" height="30" rx="15" fill="#79c0ff"/>
+  <text x="102" y="194" class="lane">FRONTEND ROUTES</text>
+  <rect x="568" y="174" width="236" height="30" rx="15" fill="#7ee787"/>
+  <text x="592" y="194" class="lane">API AND DOMAIN CORE</text>
+  <rect x="1096" y="174" width="256" height="30" rx="15" fill="#ffa657"/>
+  <text x="1122" y="194" class="lane">RUNTIME AND GOVERNANCE</text>
 
-  <rect x="78" y="224" width="430" height="548" rx="24" fill="url(#panel)" stroke="#30363d" filter="url(#shadow)"/>
-  <rect x="580" y="224" width="430" height="548" rx="24" fill="url(#panel)" stroke="#30363d" filter="url(#shadow)"/>
-  <rect x="1082" y="224" width="430" height="548" rx="24" fill="url(#panel)" stroke="#30363d" filter="url(#shadow)"/>
+  <rect x="78" y="224" width="440" height="622" rx="24" fill="url(#panel)" stroke="#30363d" filter="url(#shadow)"/>
+  <rect x="560" y="224" width="472" height="622" rx="24" fill="url(#panel)" stroke="#30363d" filter="url(#shadow)"/>
+  <rect x="1074" y="224" width="438" height="622" rx="24" fill="url(#panel)" stroke="#30363d" filter="url(#shadow)"/>
 
-  <rect x="108" y="258" width="370" height="138" rx="18" fill="url(#panelSoft)" stroke="#58a6ff"/>
-  <circle cx="152" cy="302" r="22" class="iconFillBlue"/>
-  <path d="M140 304 L152 296 L164 304 L164 318 L152 326 L140 318 Z" class="iconStroke"/>
-  <path d="M152 296 L152 310" class="iconStroke"/>
-  <path d="M140 304 L152 312 L164 304" class="iconStroke"/>
-  <text x="188" y="294" class="cardTitle">3D Object Explorer</text>
-  <text x="188" y="319" class="mono">Route: /object-explorer</text>
-  <text x="126" y="350" class="body">Stages real OBJ meshes, tactile material presets,</text>
-  <text x="126" y="374" class="body">workspace scaling, and pointer-proxy traversal.</text>
+  <rect x="108" y="256" width="178" height="182" rx="18" fill="url(#panelSoft)" stroke="#58a6ff"/>
+  <circle cx="144" cy="294" r="18" class="iconFillBlue"/>
+  <path d="M134 296 L144 289 L154 296 L154 308 L144 315 L134 308 Z" class="iconStroke"/>
+  <path d="M144 289 L144 301" class="iconStroke"/>
+  <path d="M134 296 L144 303 L154 296" class="iconStroke"/>
+  <text x="176" y="292" class="cardTitle">Object</text>
+  <text x="176" y="318" class="cardTitle">Explorer</text>
+  <text x="126" y="350" class="mono">/object-explorer</text>
+  <text x="126" y="386" class="body">OBJ staging, tactile</text>
+  <text x="126" y="410" class="body">materials, scale tuning,</text>
+  <text x="126" y="434" class="body">and live 3D exploration.</text>
 
-  <rect x="108" y="426" width="370" height="138" rx="18" fill="url(#panelSoft)" stroke="#7ee787"/>
-  <circle cx="152" cy="470" r="22" class="iconFillGreen"/>
-  <circle cx="145" cy="462" r="3.2" fill="#e6edf3"/>
-  <circle cx="159" cy="462" r="3.2" fill="#e6edf3"/>
-  <circle cx="145" cy="470" r="3.2" fill="#e6edf3"/>
-  <circle cx="159" cy="470" r="3.2" fill="#e6edf3"/>
-  <circle cx="145" cy="478" r="3.2" fill="#e6edf3"/>
-  <circle cx="159" cy="478" r="3.2" fill="#e6edf3"/>
-  <text x="188" y="462" class="cardTitle">Braille Reader</text>
-  <text x="188" y="487" class="mono">Route: /braille-reader</text>
-  <text x="126" y="518" class="body">Translates text into tactile cells, paginates them,</text>
-  <text x="126" y="542" class="body">and realizes the board as a bounded 3D surface.</text>
+  <rect x="310" y="256" width="178" height="182" rx="18" fill="url(#panelSoft)" stroke="#7ee787"/>
+  <circle cx="346" cy="294" r="18" class="iconFillGreen"/>
+  <circle cx="340" cy="287" r="2.8" fill="#e6edf3"/>
+  <circle cx="352" cy="287" r="2.8" fill="#e6edf3"/>
+  <circle cx="340" cy="294" r="2.8" fill="#e6edf3"/>
+  <circle cx="352" cy="294" r="2.8" fill="#e6edf3"/>
+  <circle cx="340" cy="301" r="2.8" fill="#e6edf3"/>
+  <circle cx="352" cy="301" r="2.8" fill="#e6edf3"/>
+  <text x="378" y="292" class="cardTitle">Braille</text>
+  <text x="378" y="318" class="cardTitle">Reader</text>
+  <text x="328" y="350" class="mono">/braille-reader</text>
+  <text x="328" y="386" class="body">Scene-native library</text>
+  <text x="328" y="410" class="body">launcher, segment load,</text>
+  <text x="328" y="434" class="body">and tactile reading world.</text>
 
-  <rect x="108" y="594" width="370" height="138" rx="18" fill="url(#panelSoft)" stroke="#c297ff"/>
-  <circle cx="152" cy="638" r="22" class="iconFillPurple"/>
-  <path d="M139 629 H154 L158 635 H166 V647 H139 Z" class="iconStroke"/>
-  <path d="M145 641 H160" class="iconStroke"/>
-  <text x="188" y="630" class="cardTitle">Haptic Desktop</text>
-  <text x="188" y="655" class="mono">Route: /haptic-desktop</text>
-  <text x="126" y="686" class="body">Builds a navigable 3D desktop with focusable objects,</text>
-  <text x="126" y="710" class="body">labels, announcements, and activation prototypes.</text>
+  <rect x="108" y="470" width="178" height="182" rx="18" fill="url(#panelSoft)" stroke="#c297ff"/>
+  <circle cx="144" cy="508" r="18" class="iconFillPurple"/>
+  <path d="M134 500 H148 L152 506 H160 V516 H134 Z" class="iconStroke"/>
+  <path d="M140 510 H154" class="iconStroke"/>
+  <text x="176" y="506" class="cardTitle">Haptic</text>
+  <text x="176" y="532" class="cardTitle">Desktop</text>
+  <text x="126" y="564" class="mono">/haptic-desktop</text>
+  <text x="126" y="600" class="body">Launcher, galleries,</text>
+  <text x="126" y="624" class="body">typed file browser, and</text>
+  <text x="126" y="648" class="body">opened content scenes.</text>
 
-  <rect x="610" y="258" width="370" height="128" rx="18" fill="url(#panelSoft)" stroke="#79c0ff"/>
-  <circle cx="654" cy="300" r="22" class="iconFillBlue"/>
-  <rect x="643" y="289" width="22" height="22" rx="4" class="iconStroke"/>
-  <path d="M648 296 H660" class="iconStroke"/>
-  <path d="M648 302 H660" class="iconStroke"/>
-  <path d="M648 308 H657" class="iconStroke"/>
-  <text x="690" y="292" class="cardTitle">FastAPI Delivery</text>
-  <text x="690" y="317" class="mono">app/main.py</text>
-  <text x="628" y="347" class="body">Serves routes, startup lifecycle, redirects,</text>
-  <text x="628" y="371" class="body">and static delivery for the three workspaces.</text>
+  <rect x="310" y="470" width="178" height="182" rx="18" fill="url(#panelSoft)" stroke="#f2cc60"/>
+  <circle cx="346" cy="508" r="18" class="iconFillYellow"/>
+  <rect x="336" y="498" width="20" height="20" rx="3.5" class="iconStroke"/>
+  <path d="M341 504 H351" class="iconStroke"/>
+  <path d="M341 510 H351" class="iconStroke"/>
+  <path d="M341 516 H348" class="iconStroke"/>
+  <text x="378" y="506" class="cardTitle">Workspace</text>
+  <text x="378" y="532" class="cardTitle">Manager</text>
+  <text x="328" y="564" class="mono">/haptic-workspace-manager</text>
+  <text x="328" y="600" class="body">Creates and registers</text>
+  <text x="328" y="624" class="body">structured descriptors</text>
+  <text x="328" y="648" class="body">rooted in external folders.</text>
 
-  <rect x="610" y="410" width="370" height="156" rx="18" fill="url(#panelSoft)" stroke="#7ee787"/>
-  <circle cx="654" cy="452" r="22" class="iconFillGreen"/>
-  <circle cx="646" cy="452" r="3.2" fill="#e6edf3"/>
-  <circle cx="662" cy="444" r="3.2" fill="#e6edf3"/>
-  <circle cx="662" cy="460" r="3.2" fill="#e6edf3"/>
-  <path d="M649 452 H659" class="iconStroke"/>
-  <path d="M646 452 L662 444" class="iconStroke"/>
-  <path d="M646 452 L662 460" class="iconStroke"/>
-  <text x="690" y="444" class="cardTitle">API Contracts</text>
-  <text x="690" y="469" class="mono">/api/health  /api/meta  /api/modes</text>
-  <text x="690" y="494" class="mono">/api/materials  /api/demo-models</text>
-  <text x="690" y="519" class="mono">/api/device/status  /api/braille/preview</text>
-  <text x="628" y="548" class="body">Exposes runtime state, public modes, material profiles,</text>
-  <text x="628" y="572" class="body">demo models, device status, and Braille translation.</text>
+  <rect x="108" y="688" width="380" height="126" rx="18" fill="url(#panelSoft)" stroke="#39d2c0"/>
+  <circle cx="144" cy="726" r="18" fill="rgba(57,210,192,0.20)" stroke="#39d2c0" stroke-width="1.6"/>
+  <path d="M134 726 H154" class="iconStroke"/>
+  <path d="M144 716 V736" class="iconStroke"/>
+  <text x="176" y="724" class="cardTitle">Shared Frontend Contract</text>
+  <text x="126" y="760" class="body">Dark technical shell, version badge, help modal,</text>
+  <text x="126" y="784" class="body">real 3D primary pane, and blind-first scene controls.</text>
 
-  <rect x="610" y="590" width="370" height="142" rx="18" fill="url(#panelSoft)" stroke="#f2cc60"/>
-  <circle cx="654" cy="632" r="22" class="iconFillYellow"/>
-  <path d="M643 624 H665" class="iconStroke"/>
-  <path d="M643 632 H665" class="iconStroke"/>
-  <path d="M643 640 H657" class="iconStroke"/>
-  <text x="690" y="624" class="cardTitle">Domain Core</text>
-  <text x="690" y="649" class="mono">braille.py  haptic_materials.py</text>
-  <text x="690" y="674" class="mono">demo_assets.py  modes.py  version.py</text>
-  <text x="628" y="704" class="body">Keeps translation, catalogs, versioning, and mode</text>
-  <text x="628" y="728" class="body">definitions independent from UI or device vendors.</text>
+  <rect x="590" y="256" width="412" height="170" rx="18" fill="url(#panelSoft)" stroke="#79c0ff"/>
+  <circle cx="630" cy="296" r="18" class="iconFillBlue"/>
+  <rect x="620" y="286" width="20" height="20" rx="3.5" class="iconStroke"/>
+  <path d="M625 292 H635" class="iconStroke"/>
+  <path d="M625 298 H635" class="iconStroke"/>
+  <path d="M625 304 H632" class="iconStroke"/>
+  <text x="662" y="294" class="cardTitle">HTTP Delivery And Mode Contracts</text>
+  <text x="662" y="322" class="mono">app/main.py   app/api/routes.py</text>
+  <text x="612" y="358" class="body">Serves four routes plus health, meta, materials,</text>
+  <text x="612" y="382" class="body">demo models, Braille preview, libraries, and workspaces.</text>
 
-  <rect x="1112" y="258" width="370" height="138" rx="18" fill="url(#panelSoft)" stroke="#ffa657"/>
-  <circle cx="1156" cy="302" r="22" class="iconFillOrange"/>
-  <rect x="1146" y="292" width="20" height="20" rx="4" class="iconStroke"/>
-  <path d="M1142 298 H1146" class="iconStroke"/>
-  <path d="M1142 306 H1146" class="iconStroke"/>
-  <path d="M1166 298 H1170" class="iconStroke"/>
-  <path d="M1166 306 H1170" class="iconStroke"/>
-  <text x="1192" y="294" class="cardTitle">Haptic Runtime</text>
-  <text x="1192" y="319" class="mono">base.py  null_backend.py  factory.py</text>
-  <text x="1130" y="350" class="body">Maintains a device boundary and a safe visual-only</text>
-  <text x="1130" y="374" class="body">fallback until a native haptic backend is attached.</text>
+  <rect x="590" y="452" width="412" height="180" rx="18" fill="url(#panelSoft)" stroke="#7ee787"/>
+  <circle cx="630" cy="492" r="18" class="iconFillGreen"/>
+  <circle cx="624" cy="485" r="2.8" fill="#e6edf3"/>
+  <circle cx="636" cy="485" r="2.8" fill="#e6edf3"/>
+  <circle cx="624" cy="492" r="2.8" fill="#e6edf3"/>
+  <circle cx="636" cy="492" r="2.8" fill="#e6edf3"/>
+  <circle cx="624" cy="499" r="2.8" fill="#e6edf3"/>
+  <circle cx="636" cy="499" r="2.8" fill="#e6edf3"/>
+  <text x="662" y="490" class="cardTitle">Domain Services And Catalogs</text>
+  <text x="662" y="518" class="mono">braille.py   library_assets.py   demo_assets.py</text>
+  <text x="662" y="542" class="mono">haptic_materials.py   haptic_workspace.py</text>
+  <text x="612" y="578" class="body">Keeps translation logic, library extraction, workspace</text>
+  <text x="612" y="602" class="body">descriptors, model catalogs, and material profiles</text>
+  <text x="612" y="626" class="body">independent from route layout or hardware vendors.</text>
 
-  <rect x="1112" y="426" width="370" height="138" rx="18" fill="url(#panelSoft)" stroke="#f2cc60"/>
-  <circle cx="1156" cy="470" r="22" class="iconFillYellow"/>
-  <path d="M1146 464 L1156 458 L1166 464 V476 L1156 482 L1146 476 Z" class="iconStroke"/>
-  <path d="M1146 464 L1156 470 L1166 464" class="iconStroke"/>
-  <path d="M1156 470 V482" class="iconStroke"/>
-  <text x="1192" y="462" class="cardTitle">Packaging And Release</text>
-  <text x="1192" y="487" class="mono">Build_PyInstaller.ps1  build.spec</text>
-  <text x="1192" y="512" class="mono">installer/FeelIT_installer.iss</text>
-  <text x="1130" y="542" class="body">Windows packaging metadata is generated from the</text>
-  <text x="1130" y="566" class="body">canonical version source before each release build.</text>
+  <rect x="590" y="658" width="412" height="156" rx="18" fill="url(#panelSoft)" stroke="#f2cc60"/>
+  <circle cx="630" cy="698" r="18" class="iconFillYellow"/>
+  <path d="M620 692 H640" class="iconStroke"/>
+  <path d="M620 700 H640" class="iconStroke"/>
+  <path d="M620 708 H636" class="iconStroke"/>
+  <text x="662" y="696" class="cardTitle">Canonical Project State</text>
+  <text x="662" y="724" class="mono">config.py   version.py   modes.py</text>
+  <text x="612" y="760" class="body">One padded version source, one port assignment, one</text>
+  <text x="612" y="784" class="body">mode catalog, and one stable runtime metadata surface.</text>
 
-  <rect x="1112" y="594" width="370" height="138" rx="18" fill="url(#panelSoft)" stroke="#ff7b72"/>
-  <circle cx="1156" cy="638" r="22" class="iconFillRed"/>
-  <path d="M1147 627 H1165 V649 H1147 Z" class="iconStroke"/>
-  <path d="M1151 631 H1161" class="iconStroke"/>
-  <path d="M1151 637 H1161" class="iconStroke"/>
-  <path d="M1151 643 H1158" class="iconStroke"/>
-  <text x="1192" y="630" class="cardTitle">Legacy Evidence</text>
-  <text x="1192" y="655" class="mono">legacy/Registro Software</text>
-  <text x="1130" y="686" class="body">Recovered manuals and source fragments verify the</text>
-  <text x="1130" y="710" class="body">Braille lineage without overclaiming lost features.</text>
+  <rect x="1104" y="256" width="378" height="170" rx="18" fill="url(#panelSoft)" stroke="#ffa657"/>
+  <circle cx="1144" cy="296" r="18" class="iconFillOrange"/>
+  <path d="M1134 290 H1154 V302 H1134 Z" class="iconStroke"/>
+  <path d="M1144 302 V314" class="iconStroke"/>
+  <text x="1176" y="294" class="cardTitle">Shared Scene Runtime</text>
+  <text x="1176" y="322" class="mono">three_scene_common.js   app.js</text>
+  <text x="1126" y="358" class="body">Provides bounded scenes, orbit controls, persistent</text>
+  <text x="1126" y="382" class="body">camera state, pointer emulation, and stage boot checks.</text>
 
-  <path d="M478 326 H580" fill="none" stroke="#79c0ff" stroke-width="5" marker-end="url(#arrowBlue)"/>
-  <path d="M478 494 H580" fill="none" stroke="#79c0ff" stroke-width="5" marker-end="url(#arrowBlue)"/>
-  <path d="M478 662 H580" fill="none" stroke="#79c0ff" stroke-width="5" marker-end="url(#arrowBlue)"/>
-  <path d="M980 488 H1082" fill="none" stroke="#79c0ff" stroke-width="5" marker-end="url(#arrowBlue)"/>
-  <path d="M980 664 H1082" fill="none" stroke="#7ee787" stroke-width="5" marker-end="url(#arrowGreen)"/>
+  <rect x="1104" y="452" width="378" height="170" rx="18" fill="url(#panelSoft)" stroke="#ffa657"/>
+  <circle cx="1144" cy="492" r="18" class="iconFillOrange"/>
+  <rect x="1134" y="482" width="20" height="20" rx="4" class="iconStroke"/>
+  <path d="M1130 488 H1134" class="iconStroke"/>
+  <path d="M1130 496 H1134" class="iconStroke"/>
+  <path d="M1154 488 H1158" class="iconStroke"/>
+  <path d="M1154 496 H1158" class="iconStroke"/>
+  <text x="1176" y="490" class="cardTitle">Haptic Boundary And Delivery</text>
+  <text x="1176" y="518" class="mono">base.py   null_backend.py   factory.py</text>
+  <text x="1176" y="542" class="mono">Build_PyInstaller.ps1   installer/FeelIT_installer.iss</text>
+  <text x="1126" y="578" class="body">Keeps the null backend as a safe fallback and derives</text>
+  <text x="1126" y="602" class="body">packaging metadata from the canonical release state.</text>
 
-  <rect x="78" y="802" width="1434" height="96" rx="22" fill="#111827" stroke="#30363d"/>
-  <text x="110" y="838" class="cardTitle">Legend</text>
-  <circle cx="134" cy="868" r="11" fill="#79c0ff"/>
-  <text x="156" y="873" class="legend">Workspace pages and scene-facing UI</text>
-  <circle cx="508" cy="868" r="11" fill="#7ee787"/>
-  <text x="530" y="873" class="legend">API contracts and reusable domain logic</text>
-  <circle cx="912" cy="868" r="11" fill="#ffa657"/>
-  <text x="934" y="873" class="legend">Runtime boundary and delivery pipeline</text>
-  <circle cx="1262" cy="868" r="11" fill="#ff7b72"/>
-  <text x="1284" y="873" class="legend">Historical evidence and claim limits</text>
+  <rect x="1104" y="648" width="378" height="166" rx="18" fill="url(#panelSoft)" stroke="#ff7b72"/>
+  <circle cx="1144" cy="688" r="18" fill="rgba(255,123,114,0.20)" stroke="#ff7b72" stroke-width="1.6"/>
+  <path d="M1134 680 H1154 V696 H1134 Z" class="iconStroke"/>
+  <path d="M1138 684 H1150" class="iconStroke"/>
+  <path d="M1138 690 H1150" class="iconStroke"/>
+  <text x="1176" y="686" class="cardTitle">Documentation And Evidence Audit</text>
+  <text x="1176" y="714" class="mono">README   docs/*.md   docs/svg   artifacts/</text>
+  <text x="1126" y="750" class="body">The shipped state, SVG suite, help content, snapshots,</text>
+  <text x="1126" y="774" class="body">and methodological history must be refreshed together.</text>
+
+  <path d="M488 347 H590" fill="none" stroke="#79c0ff" stroke-width="5" marker-end="url(#arrowBlue)"/>
+  <path d="M488 561 H590" fill="none" stroke="#79c0ff" stroke-width="5" marker-end="url(#arrowBlue)"/>
+  <path d="M488 751 H590" fill="none" stroke="#79c0ff" stroke-width="5" marker-end="url(#arrowBlue)"/>
+  <path d="M1002 341 H1104" fill="none" stroke="#79c0ff" stroke-width="5" marker-end="url(#arrowBlue)"/>
+  <path d="M1002 542 H1104" fill="none" stroke="#7ee787" stroke-width="5" marker-end="url(#arrowGreen)"/>
+  <path d="M1002 736 H1104" fill="none" stroke="#7ee787" stroke-width="5" marker-end="url(#arrowGreen)"/>
+
+  <rect x="78" y="872" width="1434" height="66" rx="20" fill="#111827" stroke="#30363d"/>
+  <text x="110" y="912" class="legend">Legend: blue panels represent route-facing surfaces, green panels represent reusable domain contracts, orange panels represent runtime and packaging boundaries, and red panels represent release-governed documentation and evidence duties.</text>
 </svg>

--- a/docs/svg/braille_pipeline.svg
+++ b/docs/svg/braille_pipeline.svg
@@ -1,9 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="940" viewBox="0 0 1600 940" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="980" viewBox="0 0 1600 980" role="img" aria-labelledby="title desc">
   <title id="title">FeelIT Braille pipeline</title>
-  <desc id="desc">Pipeline diagram for the FeelIT Braille reader from text input to API translation, 3D Braille scene realization, and future haptic mapping.</desc>
+  <desc id="desc">Pipeline diagram for the FeelIT Braille reader showing the current blind-first flow from the scene-native library launcher to segmented document loading, translation, 3D realization, and future native haptic mapping.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#0d1117"/>
+      <stop offset="50%" stop-color="#111827"/>
       <stop offset="100%" stop-color="#161b22"/>
     </linearGradient>
     <linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
@@ -13,119 +14,142 @@
     <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
       <feDropShadow dx="0" dy="14" stdDeviation="18" flood-color="#000000" flood-opacity="0.30"/>
     </filter>
-    <marker id="arrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+    <marker id="arrowBlue" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
       <path d="M0 0 L12 6 L0 12 Z" fill="#79c0ff"/>
+    </marker>
+    <marker id="arrowGreen" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+      <path d="M0 0 L12 6 L0 12 Z" fill="#7ee787"/>
     </marker>
     <style>
       .title { font: 700 40px 'Segoe UI', sans-serif; fill: #e6edf3; }
       .subtitle { font: 400 18px 'Segoe UI', sans-serif; fill: #8b949e; }
       .cardTitle { font: 700 22px 'Segoe UI', sans-serif; fill: #e6edf3; }
-      .section { font: 700 13px 'Segoe UI', sans-serif; fill: #8b949e; letter-spacing: 1.2px; }
+      .section { font: 700 13px 'Segoe UI', sans-serif; fill: #8b949e; letter-spacing: 1.1px; }
       .body { font: 400 16px 'Segoe UI', sans-serif; fill: #9fb0c3; }
       .mono { font: 400 14px Consolas, monospace; fill: #d7e2ee; }
       .badge { font: 700 12px 'Segoe UI', sans-serif; fill: #0d1117; letter-spacing: 1px; }
+      .legend { font: 600 14px 'Segoe UI', sans-serif; fill: #d3deea; }
       .smallBadge { font: 700 12px 'Segoe UI', sans-serif; fill: #e6edf3; letter-spacing: 0.8px; }
       .iconStroke { stroke: #e6edf3; stroke-width: 2.2; stroke-linecap: round; stroke-linejoin: round; fill: none; }
     </style>
   </defs>
 
-  <rect width="1600" height="940" fill="url(#bg)"/>
-  <circle cx="1410" cy="180" r="210" fill="#58a6ff" opacity="0.06"/>
-  <circle cx="280" cy="820" r="200" fill="#7ee787" opacity="0.05"/>
+  <rect width="1600" height="980" fill="url(#bg)"/>
+  <circle cx="1430" cy="170" r="220" fill="#58a6ff" opacity="0.06"/>
+  <circle cx="250" cy="860" r="220" fill="#7ee787" opacity="0.05"/>
 
-  <text x="78" y="102" class="title">Braille Translation Pipeline</text>
-  <text x="78" y="136" class="subtitle">Current runtime path from plain text input to 3D tactile scene, with a clean extension path toward future hardware mapping.</text>
+  <text x="78" y="102" class="title">Braille Runtime Pipeline</text>
+  <text x="78" y="136" class="subtitle">The verified current path already reaches a real tactile world in the browser. Native device force response remains an extension behind the same logical model.</text>
 
-  <rect x="78" y="214" width="230" height="156" rx="22" fill="url(#panel)" stroke="#79c0ff" stroke-width="2" filter="url(#shadow)"/>
-  <circle cx="122" cy="258" r="22" fill="rgba(121,192,255,0.18)" stroke="#79c0ff"/>
-  <path d="M111 252 H133" class="iconStroke"/>
-  <path d="M114 259 H130" class="iconStroke"/>
-  <path d="M117 266 H127" class="iconStroke"/>
-  <text x="158" y="252" class="cardTitle">1. Text Input</text>
-  <text x="106" y="304" class="body">The user types or pastes content into the</text>
-  <text x="106" y="328" class="body">Braille Reader workspace and chooses columns.</text>
+  <rect x="78" y="174" width="226" height="28" rx="14" fill="#79c0ff"/>
+  <text x="102" y="193" class="badge">CURRENT RUNTIME FLOW</text>
+  <rect x="1312" y="174" width="210" height="28" rx="14" fill="#7ee787"/>
+  <text x="1337" y="193" class="badge">FUTURE EXTENSION</text>
 
-  <rect x="350" y="214" width="248" height="156" rx="22" fill="url(#panel)" stroke="#58a6ff" stroke-width="2" filter="url(#shadow)"/>
-  <circle cx="394" cy="258" r="22" fill="rgba(88,166,255,0.18)" stroke="#58a6ff"/>
-  <circle cx="386" cy="258" r="3.2" fill="#e6edf3"/>
-  <circle cx="402" cy="250" r="3.2" fill="#e6edf3"/>
-  <circle cx="402" cy="266" r="3.2" fill="#e6edf3"/>
-  <path d="M389 258 H399" class="iconStroke"/>
-  <path d="M386 258 L402 250" class="iconStroke"/>
-  <path d="M386 258 L402 266" class="iconStroke"/>
-  <text x="430" y="252" class="cardTitle">2. API Request</text>
-  <text x="430" y="276" class="mono">POST /api/braille/preview</text>
-  <text x="378" y="328" class="body">The payload carries plain text and the requested</text>
-  <text x="378" y="352" class="body">column count for logical Braille layout.</text>
+  <rect x="78" y="228" width="250" height="182" rx="22" fill="url(#panel)" stroke="#79c0ff" stroke-width="2" filter="url(#shadow)"/>
+  <circle cx="122" cy="272" r="22" fill="rgba(121,192,255,0.18)" stroke="#79c0ff"/>
+  <circle cx="115" cy="264" r="3.2" fill="#e6edf3"/>
+  <circle cx="129" cy="264" r="3.2" fill="#e6edf3"/>
+  <circle cx="115" cy="272" r="3.2" fill="#e6edf3"/>
+  <circle cx="129" cy="272" r="3.2" fill="#e6edf3"/>
+  <circle cx="115" cy="280" r="3.2" fill="#e6edf3"/>
+  <circle cx="129" cy="280" r="3.2" fill="#e6edf3"/>
+  <text x="158" y="266" class="cardTitle">1. Scene Launcher</text>
+  <text x="106" y="320" class="body">The user enters the Braille route and touches a</text>
+  <text x="106" y="344" class="body">3D document target inside the library launcher.</text>
+  <text x="106" y="374" class="mono">sceneMode = library-launcher</text>
 
-  <rect x="640" y="196" width="304" height="192" rx="22" fill="url(#panel)" stroke="#7ee787" stroke-width="2" filter="url(#shadow)"/>
-  <circle cx="684" cy="246" r="22" fill="rgba(126,231,135,0.18)" stroke="#7ee787"/>
-  <circle cx="677" cy="238" r="3.2" fill="#e6edf3"/>
-  <circle cx="691" cy="238" r="3.2" fill="#e6edf3"/>
-  <circle cx="677" cy="246" r="3.2" fill="#e6edf3"/>
-  <circle cx="691" cy="246" r="3.2" fill="#e6edf3"/>
-  <circle cx="677" cy="254" r="3.2" fill="#e6edf3"/>
-  <circle cx="691" cy="254" r="3.2" fill="#e6edf3"/>
-  <text x="720" y="240" class="cardTitle">3. Core Translation</text>
-  <text x="720" y="265" class="mono">translate_text_to_cells()</text>
-  <text x="668" y="316" class="body">Normalizes characters, maps them to six-dot masks,</text>
-  <text x="668" y="340" class="body">and produces Unicode Braille cells plus dot arrays.</text>
-  <text x="668" y="372" class="mono">layout_braille_cells()</text>
+  <rect x="378" y="228" width="270" height="182" rx="22" fill="url(#panel)" stroke="#58a6ff" stroke-width="2" filter="url(#shadow)"/>
+  <circle cx="422" cy="272" r="22" fill="rgba(88,166,255,0.18)" stroke="#58a6ff"/>
+  <path d="M412 266 H434" class="iconStroke"/>
+  <path d="M415 273 H431" class="iconStroke"/>
+  <path d="M418 280 H428" class="iconStroke"/>
+  <text x="458" y="266" class="cardTitle">2. Library Segment</text>
+  <text x="458" y="292" class="mono">GET /api/library/documents</text>
+  <text x="458" y="316" class="mono">GET /api/library/documents/{slug}</text>
+  <text x="406" y="356" class="body">Bundled TXT or HTML or EPUB content is clipped by</text>
+  <text x="406" y="380" class="body">offset and max-chars before entering translation.</text>
 
-  <rect x="988" y="214" width="252" height="156" rx="22" fill="url(#panel)" stroke="#f2cc60" stroke-width="2" filter="url(#shadow)"/>
-  <circle cx="1032" cy="258" r="22" fill="rgba(242,204,96,0.18)" stroke="#f2cc60"/>
-  <path d="M1020 252 H1044" class="iconStroke"/>
-  <path d="M1020 260 H1044" class="iconStroke"/>
-  <path d="M1020 268 H1040" class="iconStroke"/>
-  <text x="1068" y="252" class="cardTitle">4. Layout Payload</text>
-  <text x="1068" y="276" class="mono">rows, columns, masks, cells</text>
-  <text x="1016" y="328" class="body">The API returns positioned cell data that is ready</text>
-  <text x="1016" y="352" class="body">to be realized as tactile geometry in the client.</text>
+  <rect x="698" y="228" width="282" height="182" rx="22" fill="url(#panel)" stroke="#7ee787" stroke-width="2" filter="url(#shadow)"/>
+  <circle cx="742" cy="272" r="22" fill="rgba(126,231,135,0.18)" stroke="#7ee787"/>
+  <circle cx="735" cy="264" r="3.2" fill="#e6edf3"/>
+  <circle cx="749" cy="264" r="3.2" fill="#e6edf3"/>
+  <circle cx="735" cy="272" r="3.2" fill="#e6edf3"/>
+  <circle cx="749" cy="272" r="3.2" fill="#e6edf3"/>
+  <circle cx="735" cy="280" r="3.2" fill="#e6edf3"/>
+  <circle cx="749" cy="280" r="3.2" fill="#e6edf3"/>
+  <text x="778" y="266" class="cardTitle">3. Preview Translation</text>
+  <text x="778" y="292" class="mono">POST /api/braille/preview</text>
+  <text x="726" y="332" class="body">The preview endpoint calls</text>
+  <text x="726" y="356" class="mono">translate_text_to_cells()</text>
+  <text x="726" y="380" class="mono">layout_braille_cells()</text>
 
-  <rect x="1282" y="214" width="240" height="156" rx="22" fill="url(#panel)" stroke="#c297ff" stroke-width="2" filter="url(#shadow)"/>
-  <circle cx="1326" cy="258" r="22" fill="rgba(194,151,255,0.18)" stroke="#c297ff"/>
-  <path d="M1314 250 H1338 V266 H1314 Z" class="iconStroke"/>
-  <path d="M1320 258 H1332" class="iconStroke"/>
-  <text x="1362" y="252" class="cardTitle">5. Client State</text>
-  <text x="1310" y="304" class="body">Pagination, selection state, and per-cell</text>
-  <text x="1310" y="328" class="body">inspection metadata are prepared for rendering.</text>
+  <rect x="1030" y="228" width="246" height="182" rx="22" fill="url(#panel)" stroke="#f2cc60" stroke-width="2" filter="url(#shadow)"/>
+  <circle cx="1074" cy="272" r="22" fill="rgba(242,204,96,0.18)" stroke="#f2cc60"/>
+  <path d="M1062 266 H1086" class="iconStroke"/>
+  <path d="M1062 274 H1086" class="iconStroke"/>
+  <path d="M1062 282 H1082" class="iconStroke"/>
+  <text x="1110" y="266" class="cardTitle">4. Layout Payload</text>
+  <text x="1110" y="292" class="mono">cells, rows, columns, masks</text>
+  <text x="1058" y="344" class="body">The client receives positioned cells plus logical</text>
+  <text x="1058" y="368" class="body">metadata ready for tactile scene realization.</text>
 
-  <rect x="216" y="546" width="472" height="234" rx="24" fill="url(#panel)" stroke="#79c0ff" stroke-width="2" filter="url(#shadow)"/>
-  <circle cx="266" cy="598" r="24" fill="rgba(121,192,255,0.18)" stroke="#79c0ff"/>
-  <circle cx="259" cy="590" r="3.2" fill="#e6edf3"/>
-  <circle cx="273" cy="590" r="3.2" fill="#e6edf3"/>
-  <circle cx="259" cy="598" r="3.2" fill="#e6edf3"/>
-  <circle cx="273" cy="598" r="3.2" fill="#e6edf3"/>
-  <circle cx="259" cy="606" r="3.2" fill="#e6edf3"/>
-  <circle cx="273" cy="606" r="3.2" fill="#e6edf3"/>
-  <text x="306" y="592" class="cardTitle">6. 3D Braille World</text>
-  <text x="306" y="616" class="mono">braille_reader.js + three_scene_common.js</text>
-  <text x="248" y="666" class="body">The current runtime builds a raised tactile board,</text>
-  <text x="248" y="690" class="body">base surface, selection focus, and scene boundaries.</text>
-  <rect x="248" y="720" width="320" height="30" rx="15" fill="rgba(242,204,96,0.16)" stroke="#f2cc60"/>
-  <text x="268" y="739" class="smallBadge">Auxiliary 2D board remains secondary for interpretation</text>
+  <rect x="1326" y="228" width="196" height="182" rx="22" fill="url(#panel)" stroke="#c297ff" stroke-width="2" filter="url(#shadow)"/>
+  <circle cx="1370" cy="272" r="22" fill="rgba(194,151,255,0.18)" stroke="#c297ff"/>
+  <path d="M1358 264 H1382 V280 H1358 Z" class="iconStroke"/>
+  <path d="M1364 272 H1376" class="iconStroke"/>
+  <text x="1406" y="266" class="cardTitle">5. Session State</text>
+  <text x="1354" y="320" class="body">Tracks current document, selected cell, library</text>
+  <text x="1354" y="344" class="body">page, segment offsets, and paired audio state.</text>
 
-  <rect x="830" y="546" width="510" height="234" rx="24" fill="url(#panel)" stroke="#ffa657" stroke-width="2" filter="url(#shadow)"/>
-  <circle cx="880" cy="598" r="24" fill="rgba(255,166,87,0.18)" stroke="#ffa657"/>
-  <rect x="870" y="588" width="20" height="20" rx="4" class="iconStroke"/>
-  <path d="M866 594 H870" class="iconStroke"/>
-  <path d="M866 602 H870" class="iconStroke"/>
-  <path d="M890 594 H894" class="iconStroke"/>
-  <path d="M890 602 H894" class="iconStroke"/>
-  <text x="920" y="592" class="cardTitle">7. Future Haptic Mapping</text>
-  <text x="920" y="616" class="mono">native device backend + force model</text>
-  <text x="862" y="666" class="body">The same logical and geometric model can later drive</text>
-  <text x="862" y="690" class="body">physical force-feedback behavior, tactile boundaries,</text>
-  <text x="862" y="714" class="body">and page navigation objects inside real device space.</text>
+  <rect x="128" y="526" width="664" height="248" rx="24" fill="url(#panel)" stroke="#79c0ff" stroke-width="2" filter="url(#shadow)"/>
+  <circle cx="178" cy="578" r="24" fill="rgba(121,192,255,0.18)" stroke="#79c0ff"/>
+  <circle cx="171" cy="570" r="3.2" fill="#e6edf3"/>
+  <circle cx="185" cy="570" r="3.2" fill="#e6edf3"/>
+  <circle cx="171" cy="578" r="3.2" fill="#e6edf3"/>
+  <circle cx="185" cy="578" r="3.2" fill="#e6edf3"/>
+  <circle cx="171" cy="586" r="3.2" fill="#e6edf3"/>
+  <circle cx="185" cy="586" r="3.2" fill="#e6edf3"/>
+  <text x="218" y="572" class="cardTitle">6. 3D Reading World</text>
+  <text x="218" y="598" class="mono">braille_reader.js + three_scene_common.js</text>
+  <text x="160" y="646" class="body">The browser builds a bounded tactile board with raised</text>
+  <text x="160" y="670" class="body">cells, an orientation cue, a page bridge, and tactile</text>
+  <text x="160" y="694" class="body">controls for previous, next, and return-to-library.</text>
 
-  <path d="M308 292 H350" fill="none" stroke="#79c0ff" stroke-width="5" marker-end="url(#arrow)"/>
-  <path d="M598 292 H640" fill="none" stroke="#79c0ff" stroke-width="5" marker-end="url(#arrow)"/>
-  <path d="M944 292 H988" fill="none" stroke="#79c0ff" stroke-width="5" marker-end="url(#arrow)"/>
-  <path d="M1240 292 H1282" fill="none" stroke="#79c0ff" stroke-width="5" marker-end="url(#arrow)"/>
-  <path d="M792 388 V546 H688" fill="none" stroke="#79c0ff" stroke-width="5" marker-end="url(#arrow)"/>
-  <path d="M1114 370 V546" fill="none" stroke="#79c0ff" stroke-width="5" marker-end="url(#arrow)"/>
+  <rect x="160" y="718" width="274" height="30" rx="15" fill="rgba(126,231,135,0.16)" stroke="#7ee787"/>
+  <text x="180" y="737" class="smallBadge">Primary control surface stays inside the 3D world</text>
+  <rect x="456" y="718" width="276" height="30" rx="15" fill="rgba(242,204,96,0.16)" stroke="#f2cc60"/>
+  <text x="476" y="737" class="smallBadge">Camera state persists across scene changes on the route</text>
 
-  <rect x="78" y="820" width="1444" height="82" rx="22" fill="#111827" stroke="#30363d"/>
-  <text x="110" y="856" class="cardTitle">Operational Baseline</text>
-  <text x="110" y="884" class="body">The current verified pipeline already reaches a real 3D tactile world in the browser. Native device force response is a future extension behind the same logical model.</text>
+  <rect x="838" y="526" width="322" height="248" rx="24" fill="url(#panel)" stroke="#ffa657" stroke-width="2" filter="url(#shadow)"/>
+  <circle cx="888" cy="578" r="24" fill="rgba(255,166,87,0.18)" stroke="#ffa657"/>
+  <rect x="878" y="568" width="20" height="20" rx="4" class="iconStroke"/>
+  <path d="M874 574 H878" class="iconStroke"/>
+  <path d="M900 574 H904" class="iconStroke"/>
+  <text x="928" y="572" class="cardTitle">7. Support Surfaces</text>
+  <text x="868" y="628" class="body">A secondary 2D board helps interpretation and an</text>
+  <text x="868" y="652" class="body">optional public-domain audio track can accompany the</text>
+  <text x="868" y="676" class="body">same document, but neither replaces tactile reading.</text>
+
+  <rect x="1208" y="526" width="314" height="248" rx="24" fill="url(#panel)" stroke="#7ee787" stroke-width="2" filter="url(#shadow)"/>
+  <circle cx="1258" cy="578" r="24" fill="rgba(126,231,135,0.18)" stroke="#7ee787"/>
+  <rect x="1248" y="568" width="20" height="20" rx="4" class="iconStroke"/>
+  <path d="M1244 574 H1248" class="iconStroke"/>
+  <path d="M1270 574 H1274" class="iconStroke"/>
+  <text x="1298" y="572" class="cardTitle">8. Native Mapping Later</text>
+  <text x="1238" y="628" class="body">The same logical cells, bounds, and navigation cues</text>
+  <text x="1238" y="652" class="body">can later drive a physical force-feedback workspace</text>
+  <text x="1238" y="676" class="body">without changing the Braille content model itself.</text>
+
+  <path d="M328 318 H378" fill="none" stroke="#79c0ff" stroke-width="5" marker-end="url(#arrowBlue)"/>
+  <path d="M648 318 H698" fill="none" stroke="#79c0ff" stroke-width="5" marker-end="url(#arrowBlue)"/>
+  <path d="M980 318 H1030" fill="none" stroke="#79c0ff" stroke-width="5" marker-end="url(#arrowBlue)"/>
+  <path d="M1276 318 H1326" fill="none" stroke="#79c0ff" stroke-width="5" marker-end="url(#arrowBlue)"/>
+  <path d="M1153 410 V468 H460 V526" fill="none" stroke="#79c0ff" stroke-width="5" marker-end="url(#arrowBlue)"/>
+  <path d="M1424 410 V526" fill="none" stroke="#79c0ff" stroke-width="5" marker-end="url(#arrowBlue)"/>
+  <path d="M1158 650 H1208" fill="none" stroke="#7ee787" stroke-width="5" marker-end="url(#arrowGreen)"/>
+
+  <rect x="78" y="836" width="1444" height="94" rx="22" fill="#111827" stroke="#30363d"/>
+  <text x="110" y="872" class="cardTitle">Operational Baseline</text>
+  <text x="110" y="904" class="legend">Blue connectors represent the verified runtime path already implemented in FeelIT 2.06.000. The green connector marks the future extension where the same Braille model can later feed a native haptic backend.</text>
 </svg>

--- a/docs/svg/legacy_to_modern.svg
+++ b/docs/svg/legacy_to_modern.svg
@@ -89,11 +89,11 @@
   <text x="1114" y="312" class="cardTitle">Modern FeelIT Scope</text>
   <text x="1114" y="340" class="mono">Operational baseline plus structured next layers</text>
   <text x="1114" y="390" class="section">OPERATIONAL NOW</text>
-  <text x="1114" y="418" class="body">Real 3D worlds for the three modes, Braille workflow,</text>
-  <text x="1114" y="442" class="body">OBJ demos, material presets, and null-device runtime.</text>
+  <text x="1114" y="418" class="body">Four routed workspaces, scene-native Braille library</text>
+  <text x="1114" y="442" class="body">launch, structured desktop workspaces, and null-safe 3D scenes.</text>
   <text x="1114" y="492" class="section">NEXT CAPABILITIES</text>
-  <text x="1114" y="520" class="body">Native haptic bridge, richer document ingestion,</text>
-  <text x="1114" y="544" class="body">desktop action graph, and stronger asset pipelines.</text>
+  <text x="1114" y="520" class="body">Native haptic bridge, richer geometry ingestion,</text>
+  <text x="1114" y="544" class="body">desktop action graph, and stronger workspace validation.</text>
   <text x="1114" y="594" class="section">DOCUMENTATION RULE</text>
   <text x="1114" y="622" class="body">Scope, architecture, theory, diagrams, and history</text>
   <text x="1114" y="646" class="body">must evolve together whenever product meaning changes.</text>

--- a/docs/svg/mode_map.svg
+++ b/docs/svg/mode_map.svg
@@ -1,13 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="940" viewBox="0 0 1600 940" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="980" viewBox="0 0 1600 980" role="img" aria-labelledby="title desc">
   <title id="title">FeelIT mode map</title>
-  <desc id="desc">Mode map for FeelIT showing the three workspaces, their focus, current maturity, and shared runtime services.</desc>
+  <desc id="desc">Mode map for FeelIT showing the four routed workspaces, their current maturity, their blind-first role, and the shared runtime contract that ties the application together.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#0d1117"/>
+      <stop offset="52%" stop-color="#111827"/>
       <stop offset="100%" stop-color="#161b22"/>
     </linearGradient>
     <linearGradient id="card" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#142030"/>
+      <stop offset="0%" stop-color="#152132"/>
       <stop offset="100%" stop-color="#101722"/>
     </linearGradient>
     <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
@@ -25,91 +26,111 @@
       .mono { font: 400 14px Consolas, monospace; fill: #d7e2ee; }
       .badge { font: 700 12px 'Segoe UI', sans-serif; fill: #0d1117; letter-spacing: 1px; }
       .smallBadge { font: 700 12px 'Segoe UI', sans-serif; fill: #e6edf3; letter-spacing: 0.8px; }
+      .legend { font: 600 14px 'Segoe UI', sans-serif; fill: #d3deea; }
       .iconStroke { stroke: #e6edf3; stroke-width: 2.2; stroke-linecap: round; stroke-linejoin: round; fill: none; }
     </style>
   </defs>
 
-  <rect width="1600" height="940" fill="url(#bg)"/>
-  <circle cx="1440" cy="190" r="220" fill="#58a6ff" opacity="0.06"/>
-  <circle cx="240" cy="820" r="200" fill="#c297ff" opacity="0.05"/>
+  <rect width="1600" height="980" fill="url(#bg)"/>
+  <circle cx="1450" cy="180" r="220" fill="#58a6ff" opacity="0.06"/>
+  <circle cx="220" cy="850" r="210" fill="#c297ff" opacity="0.05"/>
 
   <text x="78" y="102" class="title">FeelIT Mode Map</text>
-  <text x="78" y="136" class="subtitle">Each mode has a dedicated route, a dedicated task surface, and a distinct maturity level inside the same shared runtime.</text>
+  <text x="78" y="136" class="subtitle">Each route owns one primary job, but all four sit inside the same blind-first shell, device boundary, and release-governed documentation surface.</text>
 
-  <rect x="78" y="192" width="442" height="488" rx="26" fill="url(#card)" stroke="#58a6ff" stroke-width="2" filter="url(#shadow)"/>
-  <rect x="580" y="192" width="442" height="488" rx="26" fill="url(#card)" stroke="#7ee787" stroke-width="2" filter="url(#shadow)"/>
-  <rect x="1082" y="192" width="442" height="488" rx="26" fill="url(#card)" stroke="#c297ff" stroke-width="2" filter="url(#shadow)"/>
+  <rect x="78" y="192" width="684" height="274" rx="26" fill="url(#card)" stroke="#58a6ff" stroke-width="2" filter="url(#shadow)"/>
+  <rect x="838" y="192" width="684" height="274" rx="26" fill="url(#card)" stroke="#7ee787" stroke-width="2" filter="url(#shadow)"/>
+  <rect x="78" y="500" width="684" height="274" rx="26" fill="url(#card)" stroke="#c297ff" stroke-width="2" filter="url(#shadow)"/>
+  <rect x="838" y="500" width="684" height="274" rx="26" fill="url(#card)" stroke="#f2cc60" stroke-width="2" filter="url(#shadow)"/>
 
-  <circle cx="136" cy="252" r="24" fill="rgba(88,166,255,0.18)" stroke="#58a6ff"/>
-  <path d="M124 254 L136 246 L148 254 L148 268 L136 276 L124 268 Z" class="iconStroke"/>
-  <path d="M136 246 V260" class="iconStroke"/>
-  <path d="M124 254 L136 262 L148 254" class="iconStroke"/>
-  <rect x="174" y="230" width="94" height="28" rx="14" fill="#58a6ff"/>
-  <text x="196" y="248" class="badge">STAGED</text>
-  <text x="110" y="310" class="cardTitle">3D Object Explorer</text>
-  <text x="110" y="338" class="mono">/object-explorer</text>
-  <text x="110" y="388" class="section">PRIMARY PURPOSE</text>
-  <text x="110" y="416" class="body">Stage real OBJ models, assign tactile materials,</text>
-  <text x="110" y="440" class="body">and fit geometry to a bounded exploration space.</text>
-  <text x="110" y="490" class="section">CURRENT BASELINE</text>
-  <text x="110" y="518" class="body">Bundled demo assets, local OBJ upload, 3D scene</text>
-  <text x="110" y="542" class="body">controls, scale tuning, and pointer traversal.</text>
-  <text x="110" y="592" class="section">NEXT LAYER</text>
-  <text x="110" y="620" class="body">Hardware contact rendering, richer formats, and</text>
-  <text x="110" y="644" class="body">server-side validation for imported geometry.</text>
+  <circle cx="136" cy="250" r="24" fill="rgba(88,166,255,0.18)" stroke="#58a6ff"/>
+  <path d="M124 252 L136 244 L148 252 L148 266 L136 274 L124 266 Z" class="iconStroke"/>
+  <path d="M136 244 V258" class="iconStroke"/>
+  <path d="M124 252 L136 260 L148 252" class="iconStroke"/>
+  <rect x="174" y="228" width="92" height="28" rx="14" fill="#58a6ff"/>
+  <text x="196" y="246" class="badge">STAGED</text>
+  <text x="110" y="308" class="cardTitle">3D Object Explorer</text>
+  <text x="110" y="336" class="mono">/object-explorer</text>
+  <text x="110" y="382" class="section">PRIMARY ROLE</text>
+  <text x="110" y="410" class="body">Prepare bounded tactile exploration sessions for</text>
+  <text x="110" y="434" class="body">real OBJ geometry, material presets, and scale tuning.</text>
+  <text x="110" y="482" class="section">CURRENT BASELINE</text>
+  <text x="110" y="510" class="body">Bundled model catalog, local OBJ upload, persistent</text>
+  <text x="110" y="534" class="body">camera view, scene pointer traversal, and material</text>
+  <text x="110" y="558" class="body">inspection tied to plausible haptic profiles.</text>
 
-  <circle cx="638" cy="252" r="24" fill="rgba(126,231,135,0.18)" stroke="#7ee787"/>
-  <circle cx="631" cy="244" r="3.2" fill="#e6edf3"/>
-  <circle cx="645" cy="244" r="3.2" fill="#e6edf3"/>
-  <circle cx="631" cy="252" r="3.2" fill="#e6edf3"/>
-  <circle cx="645" cy="252" r="3.2" fill="#e6edf3"/>
-  <circle cx="631" cy="260" r="3.2" fill="#e6edf3"/>
-  <circle cx="645" cy="260" r="3.2" fill="#e6edf3"/>
-  <rect x="676" y="230" width="88" height="28" rx="14" fill="#7ee787"/>
-  <text x="702" y="248" class="badge">ACTIVE</text>
-  <text x="612" y="310" class="cardTitle">Braille Reader</text>
-  <text x="612" y="338" class="mono">/braille-reader</text>
-  <text x="612" y="388" class="section">PRIMARY PURPOSE</text>
-  <text x="612" y="416" class="body">Translate text into tactile cells on a bounded</text>
-  <text x="612" y="440" class="body">reading surface that matches a future haptic space.</text>
-  <text x="612" y="490" class="section">CURRENT BASELINE</text>
-  <text x="612" y="518" class="body">Live text input, pagination, 3D Braille world,</text>
-  <text x="612" y="542" class="body">auxiliary 2D board, and cell-level inspection.</text>
-  <text x="612" y="592" class="section">NEXT LAYER</text>
-  <text x="612" y="620" class="body">Document ingestion, tactile page widgets, and</text>
-  <text x="612" y="644" class="body">hardware-mapped relief and navigation behavior.</text>
+  <circle cx="896" cy="250" r="24" fill="rgba(126,231,135,0.18)" stroke="#7ee787"/>
+  <circle cx="889" cy="242" r="3.2" fill="#e6edf3"/>
+  <circle cx="903" cy="242" r="3.2" fill="#e6edf3"/>
+  <circle cx="889" cy="250" r="3.2" fill="#e6edf3"/>
+  <circle cx="903" cy="250" r="3.2" fill="#e6edf3"/>
+  <circle cx="889" cy="258" r="3.2" fill="#e6edf3"/>
+  <circle cx="903" cy="258" r="3.2" fill="#e6edf3"/>
+  <rect x="934" y="228" width="88" height="28" rx="14" fill="#7ee787"/>
+  <text x="960" y="246" class="badge">ACTIVE</text>
+  <text x="870" y="308" class="cardTitle">Braille Reader</text>
+  <text x="870" y="336" class="mono">/braille-reader</text>
+  <text x="870" y="382" class="section">PRIMARY ROLE</text>
+  <text x="870" y="410" class="body">Deliver scene-native tactile reading from a bundled</text>
+  <text x="870" y="434" class="body">library into a bounded Braille world that mirrors a</text>
+  <text x="870" y="458" class="body">future haptic reading surface.</text>
+  <text x="870" y="506" class="section">CURRENT BASELINE</text>
+  <text x="870" y="534" class="body">3D library launcher, segmented TXT or HTML or EPUB</text>
+  <text x="870" y="558" class="body">loading, preview translation, tactile page controls,</text>
+  <text x="870" y="582" class="body">optional companion audio, and a secondary debug board.</text>
 
-  <circle cx="1140" cy="252" r="24" fill="rgba(194,151,255,0.18)" stroke="#c297ff"/>
-  <path d="M1128 243 H1143 L1147 249 H1155 V261 H1128 Z" class="iconStroke"/>
-  <path d="M1134 255 H1149" class="iconStroke"/>
-  <rect x="1178" y="230" width="118" height="28" rx="14" fill="#c297ff"/>
-  <text x="1197" y="248" class="badge">PROTOTYPE</text>
-  <text x="1114" y="310" class="cardTitle">Haptic Desktop</text>
-  <text x="1114" y="338" class="mono">/haptic-desktop</text>
-  <text x="1114" y="388" class="section">PRIMARY PURPOSE</text>
-  <text x="1114" y="416" class="body">Represent folders, media, settings, and tools</text>
-  <text x="1114" y="440" class="body">as focusable tactile objects with clear semantics.</text>
-  <text x="1114" y="490" class="section">CURRENT BASELINE</text>
-  <text x="1114" y="518" class="body">3D desktop layouts, focus traversal, announcement</text>
-  <text x="1114" y="542" class="body">panel, label sprites, and activation placeholders.</text>
-  <text x="1114" y="592" class="section">NEXT LAYER</text>
-  <text x="1114" y="620" class="body">Content graph, audio services, and real execution</text>
-  <text x="1114" y="644" class="body">rules for curated desktop interactions.</text>
+  <circle cx="136" cy="558" r="24" fill="rgba(194,151,255,0.18)" stroke="#c297ff"/>
+  <path d="M124 549 H139 L143 555 H151 V567 H124 Z" class="iconStroke"/>
+  <path d="M130 561 H145" class="iconStroke"/>
+  <rect x="174" y="536" width="118" height="28" rx="14" fill="#c297ff"/>
+  <text x="193" y="554" class="badge">PROTOTYPE</text>
+  <text x="110" y="616" class="cardTitle">Haptic Desktop</text>
+  <text x="110" y="644" class="mono">/haptic-desktop</text>
+  <text x="110" y="690" class="section">PRIMARY ROLE</text>
+  <text x="110" y="718" class="body">Present a controlled tactile workspace where users</text>
+  <text x="110" y="742" class="body">move between launcher, galleries, file browser, and</text>
+  <text x="110" y="766" class="body">opened content scenes without leaving the 3D world.</text>
+  <text x="350" y="690" class="section">CURRENT BASELINE</text>
+  <text x="350" y="718" class="body">Structured workspace loading, paged galleries for</text>
+  <text x="350" y="742" class="body">models, texts, and audio, typed file browser items,</text>
+  <text x="350" y="766" class="body">and explicit Gallery or Browser plus Launcher returns.</text>
 
-  <rect x="118" y="730" width="1364" height="154" rx="24" fill="#111827" stroke="#30363d" stroke-width="2"/>
-  <text x="150" y="772" class="cardTitle">Shared Runtime Services</text>
-  <text x="150" y="804" class="body">All three modes inherit one shell, one release policy, one device boundary, and one documentation baseline.</text>
+  <circle cx="896" cy="558" r="24" fill="rgba(242,204,96,0.18)" stroke="#f2cc60"/>
+  <rect x="886" y="548" width="20" height="20" rx="3.5" class="iconStroke"/>
+  <path d="M891 554 H901" class="iconStroke"/>
+  <path d="M891 560 H901" class="iconStroke"/>
+  <path d="M891 566 H898" class="iconStroke"/>
+  <rect x="934" y="536" width="88" height="28" rx="14" fill="#f2cc60"/>
+  <text x="960" y="554" class="badge">ACTIVE</text>
+  <text x="870" y="616" class="cardTitle">Workspace Manager</text>
+  <text x="870" y="644" class="mono">/haptic-workspace-manager</text>
+  <text x="870" y="690" class="section">PRIMARY ROLE</text>
+  <text x="870" y="718" class="body">Create and register structured workspace descriptor</text>
+  <text x="870" y="742" class="body">files so large external folders can power the haptic</text>
+  <text x="870" y="766" class="body">desktop without being copied inside the application.</text>
+  <text x="1110" y="690" class="section">CURRENT BASELINE</text>
+  <text x="1110" y="718" class="body">Demo workspace bootstrapping, descriptor creation,</text>
+  <text x="1110" y="742" class="body">external-root registration, and route-level workspace</text>
+  <text x="1110" y="766" class="body">inspection for the desktop runtime.</text>
 
-  <rect x="150" y="824" width="262" height="30" rx="15" fill="rgba(88,166,255,0.16)" stroke="#58a6ff"/>
-  <text x="168" y="843" class="smallBadge">Mode navigation and help surface</text>
-  <rect x="434" y="824" width="272" height="30" rx="15" fill="rgba(126,231,135,0.16)" stroke="#7ee787"/>
-  <text x="452" y="843" class="smallBadge">Runtime status, version, and port</text>
-  <rect x="728" y="824" width="284" height="30" rx="15" fill="rgba(242,204,96,0.16)" stroke="#f2cc60"/>
-  <text x="746" y="843" class="smallBadge">Canonical version and packaging sync</text>
-  <rect x="1034" y="824" width="390" height="30" rx="15" fill="rgba(194,151,255,0.16)" stroke="#c297ff"/>
-  <text x="1052" y="843" class="smallBadge">Null haptic backend until physical device support is attached</text>
+  <rect x="78" y="830" width="1444" height="102" rx="24" fill="#111827" stroke="#30363d" stroke-width="2"/>
+  <text x="110" y="870" class="cardTitle">Shared Runtime Contract</text>
+  <text x="110" y="902" class="body">All four routes inherit one dark workbench shell, one padded version source, one null-safe haptic backend, one browser smoke baseline, and one recurring documentation plus SVG audit before a cycle can be closed.</text>
 
-  <path d="M299 680 V730" fill="none" stroke="#79c0ff" stroke-width="5" marker-end="url(#arrow)"/>
-  <path d="M801 680 V730" fill="none" stroke="#79c0ff" stroke-width="5" marker-end="url(#arrow)"/>
-  <path d="M1303 680 V730" fill="none" stroke="#79c0ff" stroke-width="5" marker-end="url(#arrow)"/>
+  <rect x="110" y="916" width="250" height="30" rx="15" fill="rgba(88,166,255,0.16)" stroke="#58a6ff"/>
+  <text x="128" y="935" class="smallBadge">Real 3D scene as the primary pane</text>
+  <rect x="384" y="916" width="262" height="30" rx="15" fill="rgba(126,231,135,0.16)" stroke="#7ee787"/>
+  <text x="402" y="935" class="smallBadge">Help, runtime status, and version surface</text>
+  <rect x="670" y="916" width="282" height="30" rx="15" fill="rgba(194,151,255,0.16)" stroke="#c297ff"/>
+  <text x="688" y="935" class="smallBadge">Pointer emulation for no-device execution</text>
+  <rect x="976" y="916" width="514" height="30" rx="15" fill="rgba(242,204,96,0.16)" stroke="#f2cc60"/>
+  <text x="994" y="935" class="smallBadge">Documentation, diagrams, snapshots, and help text must match the shipped runtime</text>
+
+  <path d="M420 774 V830" fill="none" stroke="#79c0ff" stroke-width="5" marker-end="url(#arrow)"/>
+  <path d="M1180 774 V830" fill="none" stroke="#79c0ff" stroke-width="5" marker-end="url(#arrow)"/>
+
+  <rect x="78" y="154" width="224" height="26" rx="13" fill="#79c0ff"/>
+  <text x="101" y="172" class="badge">ROUTED WORKSPACES</text>
+  <rect x="1314" y="154" width="208" height="26" rx="13" fill="rgba(255,255,255,0.10)" stroke="#30363d"/>
+  <text x="1338" y="172" class="legend">Release line: 2.06.000 baseline</text>
 </svg>

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -275,7 +275,6 @@ POST /api/haptic-workspaces/register
 - no physical device bridge is connected yet
 - 3D object staging is currently client-side and focused on `.obj`
 - document compatibility is currently limited to bundled `txt`, `html`, and `epub` assets
-- bundled Braille library selection still begins from surrounding web controls rather than a scene-native library launcher
 - workspace authoring is currently JSON-descriptor based and still needs richer validation and editing affordances
 - desktop actions are limited to models, text, audio, and file browsing rather than full desktop automation
 - haptic material profiles are plausible approximations, not full physical simulation


### PR DESCRIPTION
## Summary
- refresh FeelIT overview wording and key docs to match the current shipped baseline
- rewrite the mode map and Braille pipeline SVGs and update the architecture and legacy mapping diagrams
- keep the documentation focused on the current four-route runtime rather than older interaction assumptions

## Validation
- parsed the updated SVG suite as XML

## Notes
- no app version bump in this cycle because the runtime capability surface did not change

Closes #46